### PR TITLE
Add Near Earth Network tracking stations

### DIFF
--- a/GameData/RealAntennas/PlanetPacks/RealSolarSystem.cfg
+++ b/GameData/RealAntennas/PlanetPacks/RealSolarSystem.cfg
@@ -37,6 +37,56 @@
                     alt = 725
                     enabled = True
                 }
+                City2
+                {
+                    name = ASFTrackingStation
+                    objectName = ASF - Alaska Satellite Facility
+                    isKSC = False
+                    lat = 64.859325
+                    lon = -147.849347
+                    alt = 200
+                    enabled = True
+                }
+                City2
+                {
+                    name = SingaporeTrackingStation
+                    objectName = KSAT - Singapore
+                    isKSC = False
+                    lat = 1.396994
+                    lon = 103.834508
+                    alt = 50
+                    enabled = True
+                }
+                City2
+                {
+                    name = SantiagoTrackingStation
+                    objectName = SSC - Santiago
+                    isKSC = False
+                    lat = -33.151111
+                    lon = -70.666389
+                    alt = 733
+                    enabled = True
+                }
+                City2
+                {
+                    name = DongaraTrackingStation
+                    objectName = SSC - Dongara
+                    isKSC = False
+                    lat = -29.045258
+                    lon = 115.350111
+                    alt = 275
+                    enabled = True
+                }
+                City2
+                {
+                    name = SouthPointTrackingStation
+                    objectName = SSC - South Point
+                    isKSC = False
+                    lat = 19.014006
+                    lon = -155.663167
+                    alt = 380
+                    enabled = True
+                }
                 @City2[*TrackingStation],*
                 {
                     commnetStation = True

--- a/GameData/RealAntennas/RealismOverhaul.cfg
+++ b/GameData/RealAntennas/RealismOverhaul.cfg
@@ -62,9 +62,9 @@
     }
     BandInfo
     {
-        name = K
-        TechLevel = 9
-        Frequency = 26.250e9
+        name = Ku
+        TechLevel = 8
+        Frequency = 14.3e9
         ChannelWidth = 20e6
     }
     BandInfo
@@ -123,7 +123,7 @@
         CodingRate = 0.5
         RequiredEbN0 = 4.5
     }
-//	EncoderInfo
+//  EncoderInfo
 //    {
 //        name = Convolutional 7, 7/8
 //        reference = http://www.ieee802.org/16/tg1/phy/contrib/802161pc-00_33.pdf
@@ -166,7 +166,7 @@
         BasePower = 2
         BaseCost = 2
         CostPerWatt = 5
-        ReceiverNoiseTemperature = 27000	// 20dB
+        ReceiverNoiseTemperature = 27000    // 20dB
     }
     TechLevelInfo
     {
@@ -183,7 +183,7 @@
         BasePower = 0.3
         BaseCost = 4
         CostPerWatt = 4
-        ReceiverNoiseTemperature = 11500	// 16dB
+        ReceiverNoiseTemperature = 11500    // 16dB
     }
     TechLevelInfo
     {
@@ -200,7 +200,7 @@
         BasePower = 8
         BaseCost = 30
         CostPerWatt = 3.5
-        ReceiverNoiseTemperature = 7000	// 14dB
+        ReceiverNoiseTemperature = 7000 // 14dB
     }
     TechLevelInfo
     {
@@ -217,7 +217,7 @@
         BasePower = 19.5
         BaseCost = 50
         CostPerWatt = 3
-        ReceiverNoiseTemperature = 5800	// 13dB
+        ReceiverNoiseTemperature = 5800 // 13dB
     }
     TechLevelInfo
     {
@@ -234,7 +234,7 @@
         BasePower = 25.7
         BaseCost = 80
         CostPerWatt = 2.5
-        ReceiverNoiseTemperature = 4500	// 11.7dB
+        ReceiverNoiseTemperature = 4500 // 11.7dB
     }
     TechLevelInfo
     {
@@ -251,7 +251,7 @@
         BasePower = 23
         BaseCost = 120
         CostPerWatt = 2
-        ReceiverNoiseTemperature = 3000	// 10dB		https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19660015650.pdf
+        ReceiverNoiseTemperature = 3000 // 10dB     https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19660015650.pdf
     }
     TechLevelInfo
     {
@@ -268,7 +268,7 @@
         BasePower = 21.4
         BaseCost = 175
         CostPerWatt = 1.7
-        ReceiverNoiseTemperature = 1540	// 7.5dB
+        ReceiverNoiseTemperature = 1540 // 7.5dB
     }
     TechLevelInfo
     {
@@ -285,7 +285,7 @@
         BasePower = 18.3
         BaseCost = 125
         CostPerWatt = 1.2
-        ReceiverNoiseTemperature = 1100	// 6.1dB  https://commons.erau.edu/cgi/viewcontent.cgi?referer=https://www.google.com/&httpsredir=1&article=2697&context=space-congress-proceedings
+        ReceiverNoiseTemperature = 1100 // 6.1dB  https://commons.erau.edu/cgi/viewcontent.cgi?referer=https://www.google.com/&httpsredir=1&article=2697&context=space-congress-proceedings
     }
     TechLevelInfo
     {
@@ -302,7 +302,7 @@
         BasePower = 18.3
         BaseCost = 75
         CostPerWatt = 0.5
-        ReceiverNoiseTemperature = 500	// 2.6dB
+        ReceiverNoiseTemperature = 500  // 2.6dB
     }
     TechLevelInfo
     {
@@ -319,7 +319,7 @@
         BasePower = 11.7
         BaseCost = 50
         CostPerWatt = 0.4
-        ReceiverNoiseTemperature = 200	// 1.8dB
+        ReceiverNoiseTemperature = 200  // 1.8dB
     }
 }
 
@@ -402,7 +402,7 @@
                         UPGRADE
                         {
                             TechLevel = 4           // "Improved Comms" 1964-1966 tech node
-                            referenceGain =	60.5    // 64m Antenna: +8dB?  1967
+                            referenceGain = 60.5    // 64m Antenna: +8dB?  1967
                         }
                         UPGRADE
                         {
@@ -463,6 +463,571 @@
                         RFBand = Ka
                         AMWTemp = 20
                         ModulationBits = 2
+                    }
+                }
+                //NEN/STDN stations
+                //sources:
+                // [1] https://ntrs.nasa.gov/api/citations/20205005784/downloads/453NENUGRev5__clean_final_82420.pdf
+                // [2] https://web.archive.org/web/20100517062101/http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19750071915_1975071915.pdf
+                // [3] https://web.archive.org/web/20100523080751/http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19670008308_1967008308.pdf
+                // [4] https://www.hmdb.org/m.asp?m=13923
+                // [5] https://web.archive.org/web/20210420204240/https://science.ksc.nasa.gov/facilities/mila/milstor.html
+                // [6] http://imbrium.mit.edu/LRORS/DOCUMENT/453_HDBK_GN.PDF
+                // [7] https://sky-brokers.com/wp-content/uploads/2020/12/Datasheet-Vertex-6.1m-Cassegrain-KXK-Ku-band-Earth-Station-Antenna.pdf
+                // [8] https://www.ospo.noaa.gov/Operations/WCDAS/
+                // [9] https://digitalcommons.usu.edu/cgi/viewcontent.cgi?referer=&httpsredir=1&filename=0&article=3808&context=smallsat&type=additional
+                // [10] https://explorers.larc.nasa.gov/2023ESE/pdf_files/LEGS%20Brochure%20r20.pdf
+                // [11] https://amrc.ssec.wisc.edu/meetings/MGS/history.html#:~:text=The%20McMurdo%20Ground%20Station%20(MGS,and%20Space%20Administration%20(NASA)
+                // [12] https://core.ac.uk/download/pdf/10553337.pdf
+                // [13] https://tempo.gsfc.nasa.gov/news/New_System_Giving_SMAP_Scientists_the_Speed_They_Need
+                
+                //Cape Canaveral (MILA/PDL/KUS)
+                //MILA, Ponce deLeon and KUS are close enough together that I'm just gonna consider them one station
+                @City2[CanaveralTrackingStation]
+                {
+                    //SATAN (1964-1979)
+                    @Antenna:HAS[#RFBand[VHF]],*
+                    {
+                        // SATAN VHF system. Installed at Ft. Myers, but relocated to the cape 1972?
+                        // Reciever temp not listed in VHF band due to "high variance". Assume same as generic stations
+                        UPGRADE
+                        {
+                            TechLevel = 4               // [3] SATAN antennas installed between 1964-1966?
+                            referenceGain = 21          // [2]
+                            referenceFrequency = 136    // [2]
+                            TxPower = 64                // [2] 2.5-5.0 kW output available to VHF
+                        }
+                        //Decommissioned 1979-1980, but taking station away seems mean [5]
+                    }
+                    //TELTRAC (Also AGAVE?) 18-element (1966-2011) [5/6]
+                    @Antenna:HAS[#RFBand[UHF]],*
+                    {
+                        // Teltrac UHF system.
+                        // Reciever temp not listed in UHF band due to "high variance". Assume same as generic stations
+                        // Command antenna transmit power not listed. Assume same as generic stations (10 W)
+                        UPGRADE
+                        {
+                            TechLevel = 4               // [3] TELTRAC antennas installed 1966?
+                            referenceGain = 19          // [2]
+                            referenceFrequency = 225    // [2]
+                            TxPower = 64                // [2] 2.5-5.0 kW output?
+                        }
+                        //More modern system installed for shuttle voice backup 1992?
+                        //Decommissioned 2011, but taking station away seems mean [5]
+                    }
+                    //9m USB (uncooled) (1966)
+                    Antenna
+                    {
+                        referenceGain = 44          // [2]
+                        referenceFrequency = 2250   // [2]
+                        TxPower = 73                // [2] 20 kW available to USB transmitter
+                        TechLevel = 5               // [2] 1966? Didn't recieve command capability until later...
+                        RFBand = S                  //
+                        AMWTemp = 170               // [1]
+                        ModulationBits = 1          // [1]
+
+                        UPGRADE
+                        {
+                            TechLevel = 7               // Upgraded late 70s for shuttle?
+                            ModulationBits = 2          // [1] QPSK capable
+                        }
+                        //Kennedy Uplink Station/refurbished Ponce deLeon Station (2019)
+                        UPGRADE
+                        {
+                            TechLevel = 9               // KUS came online 2019
+                            referenceGain = 40.8        // [1] 6.1 m antenna
+                            referenceFrequency = 2200   // [1]
+                            TxPower = 47                // [1] 57 dBW EIRP. EIRP = G(dBi) + P(dBW)
+                            AMWTemp = 106               // [1] G/T 17.2, G/T = G - 10log(T). Worst case scenario at horizion (which RA already simulates?). Decrease by 0.54 based on [7] to simulate 20 degrees?
+                        }
+                    }
+                    //X and Ku-band antennas installed at MILA, but only for testing purposes?
+                }
+                
+                //GSFC Wallops tracking station
+                //Originally located in Greenbelt, relocated to Wallops?
+                @City2[*TrackingStation]:HAS[#objectName[US?-?Wallops]]
+                {
+                    @name = WallopsTrackingStation
+                    //Tracking systems of some description existed here since the early 50s, but I can't find any information on them
+
+                    @Antenna:HAS[#RFBand[VHF]],*
+                    {
+                        // 12m TLM multiband. Began construction 1965, online 1967ish?
+                        // Reciever temp not listed in VHF band due to "high variance". Assume same as generic stations
+                        UPGRADE
+                        {
+                            TechLevel = 5               // [7] Facility began construction 1965?
+                            referenceGain = 16          // [2]
+                            referenceFrequency = 136    // [2]
+                            TxPower = 64                // [2] 2.5-5.0 kW output available to VHF
+                        }
+                        UPGRADE
+                        {
+                            TechLevel = 9               // [1] Built to support ISS
+                            referenceGain = 18          // [1]
+                            referenceFrequency = 139    // [1]
+                            TxPower = 55                // [1]
+                        }
+                    }
+
+                    @Antenna:HAS[#RFBand[UHF]],*
+                    {
+                        // 12m TLM multiband. Began construction 1965, online 1967ish?
+                        UPGRADE
+                        {
+                            TechLevel = 5               // [7] Facility began construction 1965?
+                            referenceGain = 30.6        // [2]
+                            referenceFrequency = 400    // [2]
+                            TxPower = 70                // [2] 10 kW output available to UHF
+                            AMWTemp = 600               // [2]
+                        }
+                        //Decommissioned(?), but taking station away seems mean
+                    }
+
+                    Antenna
+                    {
+                        // 12m TLM multiband. Began construction 1965, online 1967ish?
+                        referenceGain = 46          // [2]
+                        referenceFrequency = 2250   // [2]
+                        TxPower = 73                // [2] 20 kW available to USB transmitter
+                        TechLevel = 5               // [2] Facility began construction 1965?
+                        RFBand = S                  //
+                        AMWTemp = 200               // [2]
+                        ModulationBits = 1          //
+                        
+                        UPGRADE
+                        {
+                            //WG1 11.28m antenna
+                            TechLevel = 8               // added in the 80s I guess?
+                            referenceGain = 45.8        // [1]
+                            referenceFrequency = 2200   // [1]
+                            TxPower = 51                // [1]
+                            AMWTemp = 123               // [1]
+                            ModulationBits = 2          // [1]
+                        }
+                    }
+                    
+                    Antenna
+                    {
+                        //WG1 11.28m antenna
+                        //This antenna can't actually transmit in X-band, but according to [8] Wallops has other high-gain antennas that can.
+                        referenceGain = 56.8        // [1]
+                        referenceFrequency = 8000   // [1]
+                        TxPower = 51                // guess
+                        TechLevel = 8               // added in the 80s I guess?
+                        RFBand = X                  //
+                        AMWTemp = 170               // [1]
+                        ModulationBits = 2          //
+                        
+                        UPGRADE
+                        {
+                            TechLevel = 9               //encoder upgrade in 2000s?
+                            ModulationBits = 6          // [1]
+                        }
+                    }
+                    //Ka/Ku-band TDRSS terminal added around 2012? Can't find information.
+                }
+                
+                //White Sands Ground Station
+                //Construction started 1976 to serve as primary TDRSS ground terminal. Limited commercial capability also offered to NEN using excess capacity
+                @City2[*TrackingStation]:HAS[#objectName[US?-?White?Sands]]
+                {
+                    @name = WhiteSandsTrackingStation
+                    
+                    Antenna
+                    {
+                        //WS1 18.3 meter antenna, S-Band
+                        referenceGain = 50          // [1]
+                        referenceFrequency = 2200   // [1]
+                        TxPower = 63                // [1] 2 kW
+                        TechLevel = 7               // [2] Installed in late 70s to support TDRSS
+                        RFBand = S                  //
+                        AMWTemp = 110               // [1]
+                        ModulationBits = 2          // [1]
+                    }
+                    Antenna
+                    {
+                        //WS1 18.3 meter antenna, X-band
+                        referenceGain = 62          // estimated
+                        referenceFrequency = 8000   // [10]
+                        TxPower = 54                // [10]
+                        TechLevel = 7               // [2] Installed in late 70s to support TDRSS
+                        RFBand = X                  //
+                        AMWTemp = 200               // [10]
+                        ModulationBits = 2          // [10]
+                    }
+                    Antenna
+                    {
+                        //WS1 18.3 meter antenna, Ku-band
+                        //Not much information available on Ku-band, but Gen1 TDRS used Ku-band as downlink channel at 14.5 GHz
+                        referenceGain = 66          // estimated
+                        referenceFrequency = 14500  // 
+                        TxPower = 54                // 
+                        TechLevel = 8               // [2] Installed in late 70s to support TDRSS
+                        RFBand = Ku                 //
+                        AMWTemp = 282               //
+                        ModulationBits = 2          //
+                        
+                        UPGRADE
+                        {
+                            TechLevel = 9           // encoder upgrades 2017?
+                            ModulationBits = 3      // [1] MTRSU can link to White Sands at 8PSK, so I guess White Sands was upgraded too
+                        }
+                    }
+                    Antenna
+                    {
+                        //WS1 18.3 meter antenna, Ka-band
+                        referenceGain = 70.5        // [1]
+                        referenceFrequency = 25500  // [1]
+                        TxPower = 49                // [10]
+                        TechLevel = 9               //
+                        RFBand = Ka                 //
+                        AMWTemp = 282               // [10]
+                        ModulationBits = 2          // [10]
+                    }
+                }
+                
+                //McMurdo Ground Station
+                //Became active 1995
+                //Also including Ku-band TDRSS uplink antenna
+                //Uses Ku-band downlink channel to create high-speed link with White Sands via TDRSS
+                @City2[MGSTrackingStation]
+                {
+                    Antenna
+                    {
+                        //MG1 10 meter antenna, S-Band
+                        referenceGain = 45          // [1]
+                        referenceFrequency = 2200   // [1]
+                        TxPower = 49                // [1]
+                        TechLevel = 8               // [11]
+                        RFBand = S                  //
+                        AMWTemp = 251               // [1]
+                        ModulationBits = 1          // [11]
+                        
+                        UPGRADE
+                        {
+                            TechLevel = 9               //encoder upgrade in 2000s?
+                            ModulationBits = 2          // [1]
+                        }
+                    }
+                    Antenna
+                    {
+                        //MG1 10 meter antenna, X-Band
+                        referenceGain = 56          // [1]
+                        referenceFrequency = 7700   // [1]
+                        TxPower = 49                // [1]
+                        TechLevel = 8               // [11]
+                        RFBand = X                  //
+                        AMWTemp = 251               // [1]
+                        ModulationBits = 2          // [11]
+                        
+                        UPGRADE
+                        {
+                            TechLevel = 9               //encoder upgrade in 2000s?
+                            ModulationBits = 6          // [1]
+                        }
+                    }
+                    Antenna
+                    {
+                        //MTRSU 4.5 meter(?) antenna, Ku-Band
+                        //Installed 1996?
+                        referenceGain = 54          // estimated
+                        referenceFrequency = 14500  //
+                        TxPower = 35                // [12]
+                        TechLevel = 8               // [11]
+                        RFBand = Ku                 // [1]
+                        AMWTemp = 251               //
+                        ModulationBits = 2          //
+                        
+                        UPGRADE
+                        {
+                            TechLevel = 9               // encoder upgrade in 2017?
+                            ModulationBits = 3          // [1]
+                        }
+                    }
+                }
+                
+                //Alaska Satellite Facility (ASF)
+                //ALso including Gilmore, Fairbanks, University, SSC North Pole, and other stations installed in Fairbanks
+                //Original radio telescopes installed 1962, command capability added later
+                @City2[ASFTrackingStation]
+                {
+                    //SATAN (1964-1979)
+                    @Antenna:HAS[#RFBand[VHF]],*
+                    {
+                        // SATAN VHF system. Installed at Ft. Myers, but relocated to the cape 1972?
+                        // Reciever temp not listed in VHF band due to "high variance". Assume same as generic stations
+                        UPGRADE
+                        {
+                            TechLevel = 4               // [3] SATAN antennas installed between 1964-1966?
+                            referenceGain = 21          // [2]
+                            referenceFrequency = 136    // [2]
+                            TxPower = 64                // [2] 2.5-5.0 kW output available to VHF
+                        }
+                        //Decommissioned 1979-1980, but taking station away seems mean [5]
+                    }
+                    //9m USB (cooled?) (1975?)
+                    Antenna
+                    {
+                        referenceGain = 44          // [2]
+                        referenceFrequency = 2250   // [2]
+                        TxPower = 73                // [2] 20 kW available to USB transmitter
+                        TechLevel = 7               // [2] 1966? Didn't recieve command capability until 1970s
+                        RFBand = S                  //
+                        AMWTemp = 95                // [2]
+                        ModulationBits = 2          // [1]
+
+                        //Alaska Satellite Facility AS1 comes online 1991
+                        UPGRADE
+                        {
+                            TechLevel = 8               //
+                            referenceGain = 45.8        // [1] 
+                            referenceFrequency = 2200   // [1]
+                            TxPower = 49                // [1] 64 dBW EIRP. EIRP = G(dBi) + P(dBW)
+                            AMWTemp = 129               // [1] G/T 22, G/T = G - 10log(T). Worst case scenario at horizion (which RA already simulates?). Decrease by 0.54 based on [7] to simulate 20 degrees?
+                        }
+                    }
+                    //Alaska Satellite Facility AS1 comes online 1991
+                    Antenna
+                    {
+                        referenceGain = 56.8        // [1]
+                        referenceFrequency = 8000   // [1]
+                        TxPower = 49                // can't actually transmit in X-band, just say same as S-band
+                        TechLevel = 8               // [1]
+                        RFBand = X                  //
+                        AMWTemp = 91                // [1]
+                        ModulationBits = 2          // 
+
+                        //encoder upgrades in 2000s?
+                        UPGRADE
+                        {
+                            TechLevel = 9               //
+                            ModulationBits = 6          // [1]
+                        }
+                    }
+                }
+                
+                //KSAT Singapore
+                //Can't find much info on this. Established 2002ish?
+                @City2[SingaporeTrackingStation]
+                {
+                    //SI1 9.1 meter antenna
+                    Antenna
+                    {
+                        referenceGain = 43.13       // [1]
+                        referenceFrequency = 2200   // [1]
+                        TxPower = 45                // [1]
+                        TechLevel = 9               // [1]
+                        RFBand = S                  //
+                        AMWTemp = 183               // [1]
+                        ModulationBits = 2          // [1]
+                    }
+                    //SI1 9.1 meter antenna
+                    Antenna
+                    {
+                        referenceGain = 55.42       // [1]
+                        referenceFrequency = 8000   // [1]
+                        TxPower = 45                // can't actually transmit in X-band, just say same as S-band
+                        TechLevel = 9               // [1]
+                        RFBand = X                  //
+                        AMWTemp = 100               // [1]
+                        ModulationBits = 2          // [1]
+                    }
+                }
+                
+                //KSAT Svalbard
+                //Established 1997
+                @City2[*TrackingStation]:HAS[#objectName[KSAT?-?Svalbard]]
+                {
+                    @name = SvalbardTrackingStation
+                    
+                    //SG3 13 meter antenna
+                    Antenna
+                    {
+                        referenceGain = 46.9        // [1]
+                        referenceFrequency = 2200   // [1]
+                        TxPower = 51                // [1]
+                        TechLevel = 8               // [1]
+                        RFBand = S                  //
+                        AMWTemp = 245               // [1]
+                        ModulationBits = 2          // [1]
+                    }
+                    //SG3 13 meter antenna
+                    Antenna
+                    {
+                        referenceGain = 59          // [1]
+                        referenceFrequency = 8000   // [1]
+                        TxPower = 51                // can't actually transmit in X-band, just say same as S-band
+                        TechLevel = 8               // [1]
+                        RFBand = X                  //
+                        AMWTemp = 132               // [1]
+                        ModulationBits = 2          // [1]
+                    }
+                }
+                
+                //KSAT Troll Station
+                //Established 2007
+                @City2[*TrackingStation]:HAS[#objectName[KSAT?-?Troll?Station]]
+                {
+                    @name = TrollsatTrackingStation
+                    
+                    //TR2 13 meter antenna
+                    Antenna
+                    {
+                        referenceGain = 41.8        // [1]
+                        referenceFrequency = 2200   // [1]
+                        TxPower = 40                // [1]
+                        TechLevel = 9               // [1]
+                        RFBand = S                  //
+                        AMWTemp = 174               // [1]
+                        ModulationBits = 2          // [1]
+                    }
+                    //TR2 13 meter antenna
+                    Antenna
+                    {
+                        referenceGain = 54          // [1]
+                        referenceFrequency = 8000   // [1]
+                        TxPower = 40                // can't actually transmit in X-band, just say same as S-band
+                        TechLevel = 9               // [1]
+                        RFBand = X                  //
+                        AMWTemp = 158               // [1]
+                        ModulationBits = 2          // [1]
+                    }
+                }
+                
+                //SANSA Hartebeesthoek/Johannesburg
+                //Originally created 1956, moved to current location 1960
+                //Radio telescope, didn't recieve command capability until later (2000s?)
+                @City2[*TrackingStation]:HAS[#objectName[STDN?-?Johannesburg]]
+                {
+                    @name = HartebeesthoekTrackingStation
+                    
+                    //HBK01 12 meter antenna
+                    Antenna
+                    {
+                        referenceGain = 46          // [2]
+                        referenceFrequency = 2200   // [1]
+                        TxPower = 53                // [1]
+                        TechLevel = 9               // [1]
+                        RFBand = S                  //
+                        AMWTemp = 229               // [1]
+                        ModulationBits = 2          //
+                    }
+                }
+                
+                //SSC Kiruna/Esrange Station
+                //Established 1978
+                @City2[*TrackingStation]:HAS[#objectName[SE?-?Esrange]]
+                {
+                    @name = EsrangeTrackingStation
+                    
+                    //KU1S 13 meter antenna
+                    Antenna
+                    {
+                        referenceGain = 46.5        // [1]
+                        referenceFrequency = 2200   // [1]
+                        TxPower = 53                // [1]
+                        TechLevel = 7               // [1]
+                        RFBand = S                  //
+                        AMWTemp = 251               // [1]
+                        ModulationBits = 2          // [1]
+                    }
+                    //KU1S 13 meter antenna
+                    Antenna
+                    {
+                        referenceGain = 60          // [1]
+                        referenceFrequency = 8000   // [1]
+                        TxPower = 53                // can't actually transmit in X-band, just say same as S-band
+                        TechLevel = 7               // [1]
+                        RFBand = X                  //
+                        AMWTemp = 178               // [1]
+                        ModulationBits = 2          //
+                        
+                        //encoder upgrades in 2000s?
+                        UPGRADE
+                        {
+                            TechLevel = 9               //
+                            ModulationBits = 3          // [1]
+                        }
+                    }
+                }
+                
+                //SSC Santiago Station
+                //Established 1958
+                @City2[SantiagoTrackingStation]
+                {
+                    //9m USB antenna (1966?)
+                    Antenna
+                    {
+                        referenceGain = 44          // [2]
+                        referenceFrequency = 2250   // [2]
+                        TxPower = 73                // [2] 20 kW available to USB transmitter
+                        TechLevel = 5               // [2] 1966? Didn't recieve command capability until later...
+                        RFBand = S                  //
+                        AMWTemp = 170               // [2]
+                        ModulationBits = 1          // [2]
+                        
+                        UPGRADE
+                        {
+                            TechLevel = 7               // Upgraded late 70s?
+                            ModulationBits = 2          // [1] QPSK capable
+                        }
+                        
+                        //SA3 13-meter Antenna online 2011
+                        UPGRADE
+                        {
+                            referenceGain = 47          // [1]
+                            referenceFrequency = 2200   // [1]
+                            TxPower = 54                // [1]
+                            TechLevel = 9               //
+                            AMWTemp = 182               // [1]
+                        }
+                    }
+                }
+                
+                //SSC Dongara Station
+                //Established 2007
+                @City2[DongaraTrackingStation]
+                {
+                    //AUWA01 13-meter antenna
+                    Antenna
+                    {
+                        referenceGain = 48          // [1]
+                        referenceFrequency = 2200   // [1]
+                        TxPower = 51                // [1]
+                        TechLevel = 9               //
+                        RFBand = S                  //
+                        AMWTemp = 281               // [1]
+                        ModulationBits = 2          // [1]
+                    }
+                }
+                
+                //SSC Souht Point Station
+                //Established 2007
+                @City2[SouthPointTrackingStation]
+                {
+                    //USHI02 13-meter antenna
+                    Antenna
+                    {
+                        referenceGain = 48          // [1]
+                        referenceFrequency = 2200   // [1]
+                        TxPower = 51                // [1]
+                        TechLevel = 9               //
+                        RFBand = S                  //
+                        AMWTemp = 282               // [1]
+                        ModulationBits = 2          // [1]
+                    }
+                    //USHI02 13-meter antenna
+                    Antenna
+                    {
+                        referenceGain = 59.1        // [1]
+                        referenceFrequency = 8000   // [1]
+                        TxPower = 59                // [1]
+                        TechLevel = 9               //
+                        RFBand = X                  //
+                        AMWTemp = 138               // [1]
+                        ModulationBits = 2          // [1]
                     }
                 }
             }


### PR DESCRIPTION
Add Near Earth Network tracking stations to RSS improve S and X-band ground station coverage at higher tech levels. Also change unused K-band to Ku-band. Also, although many of these stations are much less sensitive than the already existing DSN stations, they are capable of utilizing 8, 16 or even 32-PSK encoding, allowing them to achieve much greater data rates than the QPSK DSN stations.

Modified ground stations:

Cape Canaveral (MILA/PDL/KUS): SATAN VHF system installed 1964. TELTRAC UHF system installed 1966. 9-meter Universal S-Band installed 1966, replaced with 6.1-meter Kennedy Uplink Station S-band in 2019.
Wallops (Greenbelt/GSFC): 12-meter TLM multiband with VHF/UHF/Universal S-band capability installed 1967, replaced by 11.28-meter WG1 antenna with S and X-band capability in the 1980s.
White Sands (WSGC): 18.3-meter WS1 antenna installed in late 1970s to support TDRSS with S/X/Ku-band capability. Ka-band capability added in 2017.
McMurdo Ground Station (MGS): 10-meter MG1 antenna installed 1995 with S/X-band capability. 4.5-meter MTRSU antenna installed 1996 with Ku-band capability for communication with TDRSS.
Svalbard (SvalSat): 13-meter SG3 antenna installed 1997 with S/X-band capability.
Troll Station (TrollSat): 13-meter TR2 antenna installed 2007 with S/X-band capability.
Johannesburg (Hartebeesthoek): 12-meter HBK01 antenna given command capability in S-band in 2000s.
Esrange (Kiruna): 13-meter KU1S installed 1978 with S/X-band capability.
New ground stations:

Alaska Satellite Facility (ASF/Gilmore/Fairbanks/Ulaska/North Pole): SATAN VHF system installed 1966. 9-meter Universal S-Band antenna installed 1975, replaced by 11.3-meter AS1 with S/X-band capability in 1991.
Singapore: 9.1-meter SI1 antenna with S/X-band capability installed 2002.
Santiago (AGO): 9-meter Universal S-band antenna installed 1966. Replaced by 13-meter SA3 antenna with S-band capability in 2011.
Dongara (DON): 13-meter AUWA01 antenna with S-band capability installed 2007.
South Point: 13-meter USHI02 antenna with S/X-band capability installed 2007.