### PR TITLE
Integrate with the RP-1 config validation feature

### DIFF
--- a/GameData/RealAntennas/RealAntennasCommNetParams.cfg
+++ b/GameData/RealAntennas/RealAntennasCommNetParams.cfg
@@ -99,7 +99,7 @@ RealAntennasCommNetParams
     }
     TechLevelInfo
     {
-        name = TL0
+        name = commsTL0
         Level = 0
         Description = WW2-era
         PowerEfficiency = 0.0555
@@ -116,7 +116,7 @@ RealAntennasCommNetParams
     }
     TechLevelInfo
     {
-        name = TL1
+        name = commsTL1
         Level = 1
         Description = Lunar Range Comms, 1956: 26m antenna 1958
         PowerEfficiency = 0.0769
@@ -133,7 +133,7 @@ RealAntennasCommNetParams
     }
     TechLevelInfo
     {
-        name = TL2
+        name = commsTL2
         Level = 2
         Description = Digital Comms, 1959-1960
         PowerEfficiency = 0.1
@@ -150,7 +150,7 @@ RealAntennasCommNetParams
     }
     TechLevelInfo
     {
-        name = TL3
+        name = commsTL3
         Level = 3
         Description = Interplanetary Comms, 1961-1963: Maser 1962, S/C noise reduction 1961 (300-3000K=10dB noise temp)
         PowerEfficiency = 0.1304
@@ -167,7 +167,7 @@ RealAntennasCommNetParams
     }
     TechLevelInfo
     {
-        name = TL4
+        name = commsTL4
         Level = 4
         Description = Improved Comms, 1964-1966: 64m Antenna 1967
         PowerEfficiency = 0.1667
@@ -184,7 +184,7 @@ RealAntennasCommNetParams
     }
     TechLevelInfo
     {
-        name = TL5
+        name = commsTL5
         Level = 5
         Description = Advanced Comms, 1967-1971: Noise reduction 1968, block coding 1969
         PowerEfficiency = 0.2222
@@ -201,7 +201,7 @@ RealAntennasCommNetParams
     }
     TechLevelInfo
     {
-        name = TL6
+        name = commsTL6
         Level = 6
         Description = Deep Space Comms, 1971-1974: Antenna improvements 1971-1972, Convolutional coding ~1973
         PowerEfficiency = 0.25
@@ -218,7 +218,7 @@ RealAntennasCommNetParams
     }
     TechLevelInfo
     {
-        name = TL7
+        name = commsTL7
         Level = 7
         Description = High Data Rate Comms, 1976-1980: X-Band ~1975, concatenated coding, MW noise reduction ~1980
         PowerEfficiency = 0.3
@@ -235,7 +235,7 @@ RealAntennasCommNetParams
     }
     TechLevelInfo
     {
-        name = TL8
+        name = commsTL8
         Level = 8
         Description = Massive Scale Comms, 1986-1997: 70m antennas 1988
         PowerEfficiency = 0.3724
@@ -252,7 +252,7 @@ RealAntennasCommNetParams
     }
     TechLevelInfo
     {
-        name = TL9
+        name = commsTL9
         Level = 9
         Description = Efficient Comms, 1998-2008: Super-cooled maser & feed 1995, Ka-band 2004
         PowerEfficiency = 0.4397

--- a/GameData/RealAntennas/RealismOverhaul.cfg
+++ b/GameData/RealAntennas/RealismOverhaul.cfg
@@ -153,7 +153,7 @@
     !TechLevelInfo,* {}
     TechLevelInfo
     {
-        name = TL0
+        name = commsTL0
         Level = 0
         Description = WW2-era
         PowerEfficiency = 0.0555
@@ -170,7 +170,7 @@
     }
     TechLevelInfo
     {
-        name = TL1
+        name = commsTL1
         Level = 1
         Description = Lunar Range Comms, 1956: 26m antenna 1958
         PowerEfficiency = 0.0769
@@ -187,7 +187,7 @@
     }
     TechLevelInfo
     {
-        name = TL2
+        name = commsTL2
         Level = 2
         Description = Digital Comms, 1959-1960
         PowerEfficiency = 0.1
@@ -204,7 +204,7 @@
     }
     TechLevelInfo
     {
-        name = TL3
+        name = commsTL3
         Level = 3
         Description = Interplanetary Comms, 1961-1963: Maser 1962, S/C noise reduction 1961 (300-3000K=10dB noise temp)
         PowerEfficiency = 0.1304
@@ -221,7 +221,7 @@
     }
     TechLevelInfo
     {
-        name = TL4
+        name = commsTL4
         Level = 4
         Description = Improved Comms, 1964-1966: 64m Antenna 1967
         PowerEfficiency = 0.1667
@@ -238,7 +238,7 @@
     }
     TechLevelInfo
     {
-        name = TL5
+        name = commsTL5
         Level = 5
         Description = Advanced Comms, 1967-1971: Noise reduction 1968, block coding 1969
         PowerEfficiency = 0.2222
@@ -255,7 +255,7 @@
     }
     TechLevelInfo
     {
-        name = TL6
+        name = commsTL6
         Level = 6
         Description = Deep Space Comms, 1971-1974: Antenna improvements 1971-1972, Convolutional coding ~1973
         PowerEfficiency = 0.25
@@ -272,7 +272,7 @@
     }
     TechLevelInfo
     {
-        name = TL7
+        name = commsTL7
         Level = 7
         Description = High Data Rate Comms, 1976-1980: X-Band ~1975, concatenated coding, MW noise reduction ~1980
         PowerEfficiency = 0.3
@@ -289,7 +289,7 @@
     }
     TechLevelInfo
     {
-        name = TL8
+        name = commsTL8
         Level = 8
         Description = Massive Scale Comms, 1986-1997: 70m antennas 1988
         PowerEfficiency = 0.3724
@@ -306,7 +306,7 @@
     }
     TechLevelInfo
     {
-        name = TL9
+        name = commsTL9
         Level = 9
         Description = Efficient Comms, 1998-2008: Super-cooled maser & feed 1995, Ka-band 2004
         PowerEfficiency = 0.4397

--- a/src/RealAntennasProject/TechLevelInfo.cs
+++ b/src/RealAntennasProject/TechLevelInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using UniLinq;
 using UnityEngine;
 
 namespace RealAntennas
@@ -48,14 +49,26 @@ namespace RealAntennas
 
         public static TechLevelInfo GetTechLevel(int i)
         {
-            if (!initialized) 
-                Init(GameDatabase.Instance.GetConfigNode("RealAntennas/RealAntennasCommNetParams/RealAntennasCommNetParams"));
+            EnsureInitialized();
             i = Mathf.Clamp(i, 0, MaxTL);
             if (All.TryGetValue(i, out TechLevelInfo info))
             {
                 return info;
             }
             return All[0];
+        }
+
+        public static TechLevelInfo GetTechLevel(string name)
+        {
+            EnsureInitialized();
+            // Note: consider a separate dictionary if the lookups start getting called from hot paths
+            return All.Values.FirstOrDefault(inf => inf.name == name);
+        }
+
+        private static void EnsureInitialized()
+        {
+            if (!initialized)
+                Init(GameDatabase.Instance.GetConfigNode("RealAntennas/RealAntennasCommNetParams/RealAntennasCommNetParams"));
         }
     }
 }

--- a/src/RealAntennasProject/Tools.cs
+++ b/src/RealAntennasProject/Tools.cs
@@ -8,6 +8,20 @@ namespace RealAntennas
 {
     public class RATools : object
     {
+        private static bool? _RP1Found = null;
+        public static bool RP1Found
+        {
+            get
+            {
+                if (!_RP1Found.HasValue)
+                {
+                    var assembly = AssemblyLoader.loadedAssemblies.FirstOrDefault(a => a.assembly.GetName().Name == "RP0")?.assembly;
+                    _RP1Found = assembly != null;
+                }
+                return _RP1Found.Value;
+            }
+        }
+
         public static double LinearScale(double x) => math.pow(10, x / 10);
         public static float LinearScale(float x) => math.pow(10, x / 10);
         public static double LogScale(double x) => 10 * math.log10(x);


### PR DESCRIPTION
Now all TLs are selectable regardless of their research or unlock status!