### PR TITLE
Only display gain to one decimal place

### DIFF
--- a/src/RealAntennasProject/Tools.cs
+++ b/src/RealAntennasProject/Tools.cs
@@ -40,9 +40,11 @@ namespace RealAntennas
         public static string PrettyPrint(List<RealAntenna> list)
         {
             string s = string.Empty;
+            double roundedGain = 0;
             foreach (RealAntenna ra in list)
             {
-                s += $"{ra.RFBand.name}-Band: {ra.Gain} dBi\n";
+                roundedGain = math.Round(ra.Gain, 1);
+                s += $"{ra.RFBand.name}-Band: {roundedGain} dBi\n";
             }
             return s;
         }

--- a/src/RealAntennasProject/Tools.cs
+++ b/src/RealAntennasProject/Tools.cs
@@ -43,7 +43,7 @@ namespace RealAntennas
             double roundedGain = 0;
             foreach (RealAntenna ra in list)
             {
-                roundedGain = math.Round(ra.Gain, 1);
+                roundedGain = math.round(ra.Gain, 1);
                 s += $"{ra.RFBand.name}-Band: {roundedGain} dBi\n";
             }
             return s;

--- a/src/RealAntennasProject/Tools.cs
+++ b/src/RealAntennasProject/Tools.cs
@@ -40,11 +40,11 @@ namespace RealAntennas
         public static string PrettyPrint(List<RealAntenna> list)
         {
             string s = string.Empty;
-            double roundedGain = 0;
+            //double roundedGain = 0;
             foreach (RealAntenna ra in list)
             {
-                roundedGain = math.round(ra.Gain, 1);
-                s += $"{ra.RFBand.name}-Band: {roundedGain} dBi\n";
+                //roundedGain = math.round(ra.Gain, 1);
+                s += $"{ra.RFBand.name}-Band: {ra.Gain:F1} dBi\n";
             }
             return s;
         }

--- a/src/RealAntennasProject/Tools.cs
+++ b/src/RealAntennasProject/Tools.cs
@@ -40,10 +40,8 @@ namespace RealAntennas
         public static string PrettyPrint(List<RealAntenna> list)
         {
             string s = string.Empty;
-            //double roundedGain = 0;
             foreach (RealAntenna ra in list)
             {
-                //roundedGain = math.round(ra.Gain, 1);
                 s += $"{ra.RFBand.name}-Band: {ra.Gain:F1} dBi\n";
             }
             return s;


### PR DESCRIPTION
Prevent ground stations which use a reference frequency different than their band frequency from displaying too many decimal points in the map view.

resolves https://github.com/KSP-RO/RealAntennas/issues/15