### PR TITLE
Add comms TL10

### DIFF
--- a/GameData/RealAntennas/RealAntennas.cfg
+++ b/GameData/RealAntennas/RealAntennas.cfg
@@ -163,6 +163,11 @@
                 name__ = commsTL9
                 maxTechLevel = 9
             }
+            UPGRADE:NEEDS[RP-0]
+            {
+                name__ = commsTL10
+                maxTechLevel = 10
+            }
         }
     }
 }

--- a/GameData/RealAntennas/RealismOverhaul.cfg
+++ b/GameData/RealAntennas/RealismOverhaul.cfg
@@ -321,6 +321,30 @@
         CostPerWatt = 0.4
         ReceiverNoiseTemperature = 200  // 1.8dB
     }
+    TechLevelInfo
+    {
+        //Based on Frontier Radio DS
+        //https://digitalcommons.usu.edu/cgi/viewcontent.cgi?article=3383&context=smallsat
+        //https://www.eoportal.org/satellite-missions/frontier-radio
+        //Also this General Dynamics SSPA
+        //https://gdmissionsystems.com/-/media/General-Dynamics/Space-and-Intelligence-Systems/PDF/spaceborne-x-band-sspa-datasheet.ashx?la=en&hash=9646562DB405E956EFCAC0D2A14AB7F9FB28983A
+        //and this Thales TH4606 TWT
+        // 10.1109/IVEC56627.2023.10157133.
+        name = commsTL10
+        Level = 10
+        Description = Modern Comms, 2009-2018: 32-meter BWG noise reduction 2009, 3x34-meter antenna arraying 2018
+        PowerEfficiency = 0.4900    //TH4606 claims 49% efficiency at saturation
+        ReflectorEfficiency = 0.70  //guess. 34-meter BWG antenna is 0.75 in X-band (but 0.66 in Ka-band)
+        MinDataRate = 16
+        MaxDataRate = 134217728
+        MaxPower = 50
+        MassPerWatt = 0.09951   //1.37 kg for 17 W SSPA, 0.7 kg for 37 Watt TWT
+        BaseMass = 3.3          //Frontier Radio DS, plus 1 kg for power equipment?
+        BasePower = 9.5         //Frontier Radio DS with X-band Tx capability
+        BaseCost = 25           //guess
+        CostPerWatt = 0.4       //guess
+        ReceiverNoiseTemperature = 200  // <2 db. Same as TL9?
+    }
 }
 
 @Kopernicus:AFTER[zRealAntennas]:NEEDS[RealismOverhaul]
@@ -463,6 +487,17 @@
                         RFBand = Ka
                         AMWTemp = 20
                         ModulationBits = 2
+                        UPGRADE
+                        {
+                            TechLevel = 10
+                            //By 2018 every DSN site has at least two 34-meter antennas, allowing an array
+                            //of at least 2 antennas to be available at all time.
+                            //7264 m^2 of effective antenna area, 66% reflector efficiency at 32 GHz
+                            referenceGain = 82.34
+                            //https://ui.adsabs.harvard.edu/link_gateway/2018AcAau.147...37L/doi:10.1016/j.actaastro.2018.03.011
+                            //34-meter Ka-band AMW decreased through improved feeds for JWST at some point
+                            AMWTemp = 13.5
+                        }
                     }
                 }
                 //NEN/STDN stations

--- a/GameData/RealAntennas/TechTree.cfg
+++ b/GameData/RealAntennas/TechTree.cfg
@@ -79,3 +79,12 @@ PARTUPGRADE
 	title = Comms Tech Level 9
 	description = Upgrades Comms to Tech Level 9
 }
+//Just don't create this in stock, there's not enough nodes in the tech tree
+PARTUPGRADE:NEEDS[RP-0]
+{
+	name = commsTL10
+	partIcon = RelayAntenna50
+	techRequired:NEEDS[RP-0] = modernComms
+	title = Comms Tech Level 10
+	description = Upgrades Comms to Tech Level 10
+}

--- a/GameData/RealAntennas/TechTree.cfg
+++ b/GameData/RealAntennas/TechTree.cfg
@@ -84,7 +84,7 @@ PARTUPGRADE:NEEDS[RP-0]
 {
 	name = commsTL10
 	partIcon = RelayAntenna50
-	techRequired:NEEDS[RP-0] = modernComms
+	techRequired = modernComms
 	title = Comms Tech Level 10
 	description = Upgrades Comms to Tech Level 10
 }


### PR DESCRIPTION
Since the existing tech levels stop at 2008, create TL10 for the 2009-2018 node. Mostly based on the communications package in the Parker Solar Probe; COTS software-defined radios, GaN solid state power supplies, and improved TWTAs greatly reduce the mass of communications equipment, while also bringing minor gains in efficiency.

No significant improvements on the DSN side, but improvements to the Ka-band feeds reduces antenna noise, and construction of additional 34-meter BWG antennas means 2 34-meter antennas are available at all times for arrayed operations, improving the effective gain in the Ka-band.

Needs https://github.com/KSP-RO/RP-1/pull/2396