### PR TITLE
Planner ground station band filtering

### DIFF
--- a/src/RealAntennasProject/PlannerGUI.cs
+++ b/src/RealAntennasProject/PlannerGUI.cs
@@ -257,7 +257,7 @@ namespace RealAntennas
                 }
                 foreach (Network.RACommNetHome home in homes)
                     foreach (RealAntenna ra in home.Comm.RAAntennaList)
-						if(CheckMatchingGroundStation(peer, ra)
+						if(CheckMatchingGroundStation(peer, ra))
 							if (GUILayout.Button($"{home.displaynodeName} {ra.ToStringShort()}", buttonStyle))
 							{
 								antenna = ra;

--- a/src/RealAntennasProject/PlannerGUI.cs
+++ b/src/RealAntennasProject/PlannerGUI.cs
@@ -256,15 +256,25 @@ namespace RealAntennas
                     res = true;
                 }
                 foreach (Network.RACommNetHome home in homes)
-                    foreach (RealAntenna ra in home.Comm.RAAntennaList.Where(x => x.Compatible(peer)))
-                        if (GUILayout.Button($"{home.displaynodeName} {ra.ToStringShort()}", buttonStyle))
-                        {
-                            antenna = ra;
-                            res = true;
-                        }
+                    foreach (RealAntenna ra in home.Comm.RAAntennaList)
+						if(CheckMatchingGroundStation(peer, ra)
+							if (GUILayout.Button($"{home.displaynodeName} {ra.ToStringShort()}", buttonStyle))
+							{
+								antenna = ra;
+								res = true;
+							}
             }
             GUILayout.EndScrollView();
             return res;
+        }
+
+		public bool CheckMatchingGroundStation(RealAntenna peer, RealAntenna station)
+        {
+            if(peer.RFBand == station.RFBand)
+			{
+				return true;
+			}
+			return false;
         }
 
         public RealAntenna GetBestMatchingGroundStation(RealAntenna peer, IEnumerable<Network.RACommNetHome> stations)

--- a/src/RealAntennasProject/PlannerGUI.cs
+++ b/src/RealAntennasProject/PlannerGUI.cs
@@ -259,9 +259,9 @@ namespace RealAntennas
                     foreach (RealAntenna ra in home.Comm.RAAntennaList)
                         if (peer.Compatible(ra) && GUILayout.Button($"{home.displaynodeName} {ra.ToStringShort()}", buttonStyle))
                         {
-							antenna = ra;
-							res = true;
-						}
+                            antenna = ra;
+                            res = true;
+                        }
             }
             GUILayout.EndScrollView();
             return res;

--- a/src/RealAntennasProject/PlannerGUI.cs
+++ b/src/RealAntennasProject/PlannerGUI.cs
@@ -257,24 +257,14 @@ namespace RealAntennas
                 }
                 foreach (Network.RACommNetHome home in homes)
                     foreach (RealAntenna ra in home.Comm.RAAntennaList)
-						if(CheckMatchingGroundStation(peer, ra))
-							if (GUILayout.Button($"{home.displaynodeName} {ra.ToStringShort()}", buttonStyle))
-							{
-								antenna = ra;
-								res = true;
-							}
+                        if (peer.Compatible(ra) && GUILayout.Button($"{home.displaynodeName} {ra.ToStringShort()}", buttonStyle))
+                        {
+							antenna = ra;
+							res = true;
+						}
             }
             GUILayout.EndScrollView();
             return res;
-        }
-
-		public bool CheckMatchingGroundStation(RealAntenna peer, RealAntenna station)
-        {
-            if(peer.RFBand == station.RFBand)
-			{
-				return true;
-			}
-			return false;
         }
 
         public RealAntenna GetBestMatchingGroundStation(RealAntenna peer, IEnumerable<Network.RACommNetHome> stations)

--- a/src/RealAntennasProject/PlannerGUI.cs
+++ b/src/RealAntennasProject/PlannerGUI.cs
@@ -256,7 +256,7 @@ namespace RealAntennas
                     res = true;
                 }
                 foreach (Network.RACommNetHome home in homes)
-                    foreach (RealAntenna ra in home.Comm.RAAntennaList)
+                    foreach (RealAntenna ra in home.Comm.RAAntennaList.Where(x => x.Compatible(peer)))
                         if (GUILayout.Button($"{home.displaynodeName} {ra.ToStringShort()}", buttonStyle))
                         {
                             antenna = ra;


### PR DESCRIPTION
Exclude ground stations with incompatible antenna bands from the planner. This should make finding a specific ground station much easier, especially in the higher RF bands, as you will no longer need to scroll past all the launch site tracking stations.

This works, but someone who understands C# should probably look at the code to make sure I'm not doing something horrible

resolves https://github.com/KSP-RO/RealAntennas/issues/3