### PR TITLE
Improve Stock (Kerbol) system configs

### DIFF
--- a/GameData/RealAntennas/PlanetPacks/Stock.cfg
+++ b/GameData/RealAntennas/PlanetPacks/Stock.cfg
@@ -11,6 +11,26 @@
         {
             @Mods
             {
+				City2
+                {
+                    name = WoomerangTrackingStation
+                    objectName = Woomerang Station
+                    isKSC = True
+                    lat = 45.29
+                    lon = 136.12
+                    alt = 777
+                    enabled = True
+                }
+				City2
+                {
+                    name = DessertTrackingStation
+                    objectName = Dessert Station
+                    isKSC = True
+                    lat = -6.5203
+                    lon = -144.0194
+                    alt = 873
+                    enabled = True
+                }
                 City2
                 {
                     name = DSNTrackingStation

--- a/GameData/RealAntennas/PlanetPacks/Stock.cfg
+++ b/GameData/RealAntennas/PlanetPacks/Stock.cfg
@@ -11,9 +11,11 @@
         {
             @Mods
             {
-                City2
+                //launch site tracking stations
+                //this probably spoils their locations but whatever
+                City2:NEEDS[SquadExpansion/MakingHistory] // Only appears with MH installed
                 {
-                    name = WoomerangTrackingStation
+                    name = LaunchSiteTrackingStation
                     objectName = Woomerang Station
                     isKSC = True
                     lat = 45.29
@@ -21,9 +23,9 @@
                     alt = 777
                     enabled = True
                 }
-                City2
+                City2:NEEDS[SquadExpansion/MakingHistory] // Only appears with MH installed
                 {
-                    name = DessertTrackingStation
+                    name = LaunchSiteTrackingStation
                     objectName = Dessert Station
                     isKSC = True
                     lat = -6.5203
@@ -31,6 +33,91 @@
                     alt = 873
                     enabled = True
                 }
+                City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = Glacier Lake Station
+                    isKSC = True
+                    lat = 73.5527
+                    lon = 84.3166
+                    alt = 77
+                    enabled = True
+                }
+                City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = Cove Station
+                    isKSC = True
+                    lat = 3.7523
+                    lon = -72.2248
+                    alt = 56
+                    enabled = True
+                }
+                City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = Mahi Mahi Station
+                    isKSC = True
+                    lat = -49.8044
+                    lon = -120.7923
+                    alt = 102
+                    enabled = True
+                }
+                City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = Crater Station
+                    isKSC = True
+                    lat = 8.3651
+                    lon = -179.6882
+                    alt = 137
+                    enabled = True
+                }
+                //Near Kerbin Network tracking stations
+                //weaker tracking stations for near-kerbin use
+                //These are supposed to be optional but RA doesn't support that at the moment
+                City2
+                {
+                    name = NKNTrackingStation
+                    objectName = Baikerbanur Station
+                    isKSC = True
+                    lat = 20.679167
+                    lon = -146.501111
+                    alt = 450
+                    enabled = True
+                }
+                City2
+                {
+                    name = NKNTrackingStation
+                    objectName = Nye Island Station
+                    isKSC = True
+                    lat = 5.363611
+                    lon = 108.548056
+                    alt = 415
+                    enabled = True
+                }
+                City2
+                {
+                    name = NKNTrackingStation
+                    objectName = North Station One
+                    isKSC = True
+                    lat = 63.095
+                    lon = -90.079722
+                    alt = 2823
+                    enabled = True
+                }
+                City2
+                {
+                    name = NKNTrackingStation
+                    objectName = Mesa South Station
+                    isKSC = True
+                    lat = -59.589722
+                    lon = -25.861667
+                    alt = 5470
+                    enabled = True
+                }
+                //DSN tracking stations
+                //high-powered stations for deep space communication
                 City2
                 {
                     name = DSNTrackingStation
@@ -41,24 +128,26 @@
                     alt = 93.7
                     enabled = True
                 }
+                //promote two generic tracking stations to DSN stations so we have 3 mostly evenly-spaced
+                //DSN stations for total deep space coverage
                 City2
                 {
                     name = DSNTrackingStation
-                    objectName = Charon Station
-                    isKSC = False
-                    lat = 0
-                    lon = 54
-                    alt = 299.9
+                    objectName = Harvester Massif Station
+                    isKSC = True
+                    lat = -11.95
+                    lon = 33.740278
+                    alt = 2697
                     enabled = True
                 }
                 City2
                 {
                     name = DSNTrackingStation
-                    objectName = Pluto Station
-                    isKSC = False
-                    lat = 0
-                    lon = 174
-                    alt = 3412.2
+                    objectName = Crater Rim Station
+                    isKSC = True
+                    lat = 9.45
+                    lon = -172.110278
+                    alt = 4053
                     enabled = True
                 }
                 @City2[*TrackingStation],*

--- a/GameData/RealAntennas/PlanetPacks/Stock.cfg
+++ b/GameData/RealAntennas/PlanetPacks/Stock.cfg
@@ -11,7 +11,7 @@
         {
             @Mods
             {
-				City2
+                City2
                 {
                     name = WoomerangTrackingStation
                     objectName = Woomerang Station
@@ -21,7 +21,7 @@
                     alt = 777
                     enabled = True
                 }
-				City2
+                City2
                 {
                     name = DessertTrackingStation
                     objectName = Dessert Station

--- a/GameData/RealAntennas/RealAntennasCommNetParams.cfg
+++ b/GameData/RealAntennas/RealAntennasCommNetParams.cfg
@@ -303,7 +303,7 @@ Kopernicus:NEEDS[!Kopernicus]
                     %icon = RealAntennas/radio-antenna
                     Antenna
                     {
-                        referenceGain = 6
+                        referenceGain = 3
                         referenceFrequency = 1620
                         TxPower = 40                // 10W
                         TechLevel = 0
@@ -323,53 +323,47 @@ Kopernicus:NEEDS[!Kopernicus]
                     }
                     Antenna
                     {
-                        referenceGain = 52.5        // 26m antenna 1958
+                        referenceGain = 40
                         referenceFrequency = 2250
-                        TxPower = 63                // 2KW
-                        TechLevel = 3
+                        TxPower = 60
+                        TechLevel = 3               // Basic Science
                         RFBand = S
                         AMWTemp = 125
                         ModulationBits = 1
 
                         UPGRADE
                         {
-                            TechLevel = 4           // "Improved Comms" 1964-1966 tech node
-                            referenceGain =	60.5    // 64m Antenna: +8dB?  1967
+                            TechLevel = 5           // Precision Engineering
+                            AMWTemp = 80
                         }
                         UPGRADE
                         {
-                            TechLevel = 5           // "Advanced Comms" 1967-1971 tech node (1967-1970)
-                            AMWTemp = 80            // Noise reduction 1968, block coding 1969
+                            TechLevel = 7           // Automation
+                            ModulationBits = 2
                         }
                     }
                     Antenna
                     {
-                        referenceGain = 73.5        // X-Band 64m
+                        referenceGain = 51
                         referenceFrequency = 8450
-                        TxPower = 70                // 10KW
-                        TechLevel = 7
+                        TxPower = 60
+                        TechLevel = 7               // Automation
                         RFBand = X
                         AMWTemp = 40
                         ModulationBits = 2
 
                         UPGRADE
                         {
-                            TechLevel = 8
-                            referenceGain = 74.3
-                            TxPower = 73
-                        }
-                        UPGRADE
-                        {
-                            TechLevel = 9
+                            TechLevel = 9           // Experimental Electronics
                             AMWTemp = 12.8
                         }
                     }
                     Antenna
                     {
-                        referenceGain = 79          // K-Band 34m
+                        referenceGain = 61          // K-Band 34m
                         referenceFrequency = 26250
-                        TxPower = 54.8
-                        TechLevel = 9
+                        TxPower = 50
+                        TechLevel = 9               // Experimental Electronics
                         RFBand = K
                         AMWTemp = 20
                         ModulationBits = 2

--- a/GameData/RealAntennas/RealAntennasCommNetParams.cfg
+++ b/GameData/RealAntennas/RealAntennasCommNetParams.cfg
@@ -301,15 +301,36 @@ Kopernicus:NEEDS[!Kopernicus]
                     %commnetStation = False
                     RACommNetStation = True
                     %icon = RealAntennas/radio-antenna
+                    //Every station gets a basic L-band omni for launch tracking and control
                     Antenna
                     {
-                        referenceGain = 3
+                        referenceGain = 1.5
                         referenceFrequency = 1620
                         TxPower = 40                // 10W
                         TechLevel = 0
                         RFBand = L
                         AMWTemp = 290
                         ModulationBits = 1          // BPSK only
+                    }
+                }
+                @City2[NKNTrackingStation],*
+                {
+                    //NKN stations get upgraded with a very weak S-band
+                    Antenna
+                    {
+                        referenceGain = 6
+                        referenceFrequency = 2250
+                        TxPower = 40
+                        TechLevel = 5               // Precision Engineering
+                        RFBand = S
+                        AMWTemp = 290
+                        ModulationBits = 1
+
+                        UPGRADE
+                        {
+                            TechLevel = 7           // Automation
+                            ModulationBits = 2
+                        }
                     }
                 }
                 @City2[DSNTrackingStation],*


### PR DESCRIPTION
Attempt to actually balance RealAntennas when used in Kerbol or Kerbol-sized systems.

This mostly consists of significantly reducing the DSN gain, as it was previously using configs copied from the real DSN, which was grossly overpowered for the Kerbol system and meant even omni Antennas could trivially establish connections at Eeloo and beyond.

It's still a little overpowered, but I was unwilling to make the DSN stations weaker than the stock antennas available to the player, and didn't really want to open the can of worms that is changing antenna bands (X and K-band are probably too much for the Kerbol system, even small antennas can achieve extremely high gain and ranges).

With these new settings, the lower tech levels are balanced very similarly with the stock level 1 tracking station. The S-band unlock at TL3 grants superior range than the stock Level 2 DSN, but it's still not enough to achieve a connection with Eve/Duna except at closest approach, so the balance should be about the same. Once you get into the high tech levels, the large dish antennas do perform much better than their stock counterparts, and once X-band is unlocked dish antennas can trivially establish connections with the DSN at Terameter ranges (the Kerbol system is about 160 Gigameters across), but it's probably fine, they need to be a lot closer to get good data rates.

This also adds basic tracking stations for all alternate launch sites and extra ground stations located on kerbin.

Edit: Just tested with OPM, establishing a decent connection with Plock is still perfectly doable with stock antennas, if a little power-hungry.