### PR TITLE
Galileo's planet pack configs

### DIFF
--- a/GameData/RealAntennas/PlanetPacks/GPP.cfg
+++ b/GameData/RealAntennas/PlanetPacks/GPP.cfg
@@ -1,0 +1,213 @@
+// Insert stock ground stations into Kopernicus structure
+// There isn't a good way to detect that no planet packs are installed.
+// Hack: Long :NEEDS[!PlanetPack1,!PlanetPack2,...] statement
+// Other option is to rename this file to .disabled, and re-enable in Kopernicus+stock circumstance.
+
+//The stock file always runs (due to above-mentioned issue) so run this after it to override
+@Kopernicus:FOR[RealAntennas_Late]:NEEDS[Kopernicus,GPP]
+{
+    @Body[Kerbin]
+    {
+        @PQS
+        {
+            @Mods
+            {
+				!City2,* {}
+                //launch site tracking stations
+                //this probably spoils their locations but whatever
+                City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = Broken Arrow Station
+                    isKSC = True
+                    lat = -18.0315
+                    lon = 116.3976
+                    alt = 356
+                    enabled = True
+                }
+                City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = Cironaut's Hope Station
+                    isKSC = True
+                    lat = 42.4416
+                    lon = -31.5262
+                    alt = 450
+                    enabled = True
+                }
+				City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = Point Spetses Station
+                    isKSC = True
+                    lat = 51.3706
+                    lon = 159.0911
+                    alt = 552
+                    enabled = True
+                }
+				City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = Southern Site Station
+                    isKSC = True
+                    lat = -61.0836
+                    lon = -0.5974
+                    alt = 624
+                    enabled = True
+                }
+				City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = Rook's Glory Station
+                    isKSC = True
+                    lat = -0.0432
+                    lon = 35.9208
+                    alt = 531
+                    enabled = True
+                }
+				City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = Rover Test Site Station
+                    isKSC = True
+                    lat = 23.3736
+                    lon = -57.2369
+                    alt = 1446
+                    enabled = True
+                }
+				City2:NEEDS[SquadExpansion/MakingHistory] // Only appears with MH installed
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = Woomerang Station
+                    isKSC = True
+                    lat = 45.2901
+                    lon = 136.12
+                    alt = 146
+                    enabled = True
+                }
+                //Near Kerbin Network tracking stations
+                //weaker tracking stations for near-kerbin use
+                //These are supposed to be optional but RA doesn't support that at the moment
+                City2
+                {
+                    name = NKNTrackingStation
+                    objectName = Baikerbanur Station
+                    isKSC = True
+                    lat = 20.679167
+                    lon = -146.501111
+                    alt = 450
+                    enabled = True
+                }
+                City2
+                {
+                    name = NKNTrackingStation
+                    objectName = Nye Island Station
+                    isKSC = True
+                    lat = 5.363611
+                    lon = 108.548056
+                    alt = 73
+                    enabled = True
+                }
+                City2
+                {
+                    name = NKNTrackingStation
+                    objectName = North Station One
+                    isKSC = True
+                    lat = 63.095
+                    lon = -90.079722
+                    alt = 423
+                    enabled = True
+                }
+                City2
+                {
+                    name = NKNTrackingStation
+                    objectName = Mesa South Station
+                    isKSC = True
+                    lat = -59.589722
+                    lon = -25.861667
+                    alt = 1313
+                    enabled = True
+                }
+                City2
+                {
+                    name = NKNTrackingStation
+                    objectName = Harvester Massif Station
+                    isKSC = True
+                    lat = -11.95
+                    lon = 33.740278
+                    alt = 650
+                    enabled = True
+                }
+				//don't configure crater rim station, it's nearly on top of the GSC anyway
+				//Instead, promote DomRok. It's positioned more usefully.
+                City2
+                {
+                    name = LaunchSiteTrackingStation
+                    objectName = DomRok Station
+                    isKSC = True
+                    lat = -7.2742
+                    lon = -114.7734
+                    alt = 817
+                    enabled = True
+                }
+                //DSN tracking stations
+                //high-powered stations for deep space communication
+                City2
+                {
+                    name = DSNTrackingStation
+                    objectName = Gael Space Center
+                    isKSC = True
+                    lat = 8.6096
+                    lon = -168.2248
+                    alt = 58
+                    enabled = True
+                }
+                City2
+                {
+                    name = DSNTrackingStation
+                    objectName = Charon Station
+                    isKSC = False
+					//located on a convenient island
+                    lat = 0.3569
+                    lon = 54.1042
+                    alt = 341
+                    enabled = True
+                }
+				City2
+                {
+                    name = DSNTrackingStation
+                    objectName = Northern Valley Station
+                    isKSC = True
+					//In about the right place for good coverage
+                    lat = 15.5771
+                    lon = -32.2899
+                    alt = 576
+                    enabled = True
+                }
+                @City2[*TrackingStation],*
+                {
+                    commnetStation = True
+                    snapToSurface = True
+                    snapHeightOffset = 0
+                    up = 0.0, 1.0, 0.0
+                    rotation = 0
+                    order = 100
+                }
+                @City2[*TrackingStation],*
+                {
+                    LOD
+                    {
+                        Value
+                        {
+                            visibleRange = 30000
+                            keepActive = False
+                            model = BUILTIN/Dish
+                            scale = 0.1, 0.1, 0.1
+                            delete = False
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/GameData/RealAntennas/RealAntennasCommNetParams.cfg
+++ b/GameData/RealAntennas/RealAntennasCommNetParams.cfg
@@ -301,15 +301,36 @@ Kopernicus:NEEDS[!Kopernicus]
                     %commnetStation = False
                     RACommNetStation = True
                     %icon = RealAntennas/radio-antenna
+                    //Every station gets a basic L-band omni for launch tracking and control
                     Antenna
                     {
-                        referenceGain = 6
+                        referenceGain = 1.5
                         referenceFrequency = 1620
                         TxPower = 40                // 10W
                         TechLevel = 0
                         RFBand = L
                         AMWTemp = 290
                         ModulationBits = 1          // BPSK only
+                    }
+                }
+                @City2[NKNTrackingStation],*
+                {
+                    //NKN stations get upgraded with a very weak S-band
+                    Antenna
+                    {
+                        referenceGain = 6
+                        referenceFrequency = 2250
+                        TxPower = 40
+                        TechLevel = 5               // Precision Engineering
+                        RFBand = S
+                        AMWTemp = 290
+                        ModulationBits = 1
+
+                        UPGRADE
+                        {
+                            TechLevel = 7           // Automation
+                            ModulationBits = 2
+                        }
                     }
                 }
                 @City2[DSNTrackingStation],*
@@ -323,53 +344,47 @@ Kopernicus:NEEDS[!Kopernicus]
                     }
                     Antenna
                     {
-                        referenceGain = 52.5        // 26m antenna 1958
+                        referenceGain = 40
                         referenceFrequency = 2250
-                        TxPower = 63                // 2KW
-                        TechLevel = 3
+                        TxPower = 60
+                        TechLevel = 3               // Basic Science
                         RFBand = S
                         AMWTemp = 125
                         ModulationBits = 1
 
                         UPGRADE
                         {
-                            TechLevel = 4           // "Improved Comms" 1964-1966 tech node
-                            referenceGain =	60.5    // 64m Antenna: +8dB?  1967
+                            TechLevel = 5           // Precision Engineering
+                            AMWTemp = 80
                         }
                         UPGRADE
                         {
-                            TechLevel = 5           // "Advanced Comms" 1967-1971 tech node (1967-1970)
-                            AMWTemp = 80            // Noise reduction 1968, block coding 1969
+                            TechLevel = 7           // Automation
+                            ModulationBits = 2
                         }
                     }
                     Antenna
                     {
-                        referenceGain = 73.5        // X-Band 64m
+                        referenceGain = 51
                         referenceFrequency = 8450
-                        TxPower = 70                // 10KW
-                        TechLevel = 7
+                        TxPower = 60
+                        TechLevel = 7               // Automation
                         RFBand = X
                         AMWTemp = 40
                         ModulationBits = 2
 
                         UPGRADE
                         {
-                            TechLevel = 8
-                            referenceGain = 74.3
-                            TxPower = 73
-                        }
-                        UPGRADE
-                        {
-                            TechLevel = 9
+                            TechLevel = 9           // Experimental Electronics
                             AMWTemp = 12.8
                         }
                     }
                     Antenna
                     {
-                        referenceGain = 79          // K-Band 34m
+                        referenceGain = 61          // K-Band 34m
                         referenceFrequency = 26250
-                        TxPower = 54.8
-                        TechLevel = 9
+                        TxPower = 50
+                        TechLevel = 9               // Experimental Electronics
                         RFBand = K
                         AMWTemp = 20
                         ModulationBits = 2


### PR DESCRIPTION
Configs for Galileo's planet pack. Mostly just copied from the Kerbin configs, but with stations added or repositioned for Gael launch sites.

Needs https://github.com/KSP-RO/RealAntennas/pull/32