### PR TITLE
Fix Skopos station AMWTemp (and any other non-ground-station things that want to use it)

### DIFF
--- a/src/RealAntennasProject/ModuleRealAntenna.cs
+++ b/src/RealAntennasProject/ModuleRealAntenna.cs
@@ -190,20 +190,6 @@ namespace RealAntennas
             }
         }
 
-        public void FixedUpdate()
-        {
-            if (HighLogic.LoadedSceneIsFlight && _enabled)
-            {
-                RAAntenna.AMWTemp = (AMWTemp > 0) ? AMWTemp : Convert.ToSingle(part.temperature);
-                //part.AddThermalFlux(req / Time.fixedDeltaTime);
-                if (Kerbalism.Kerbalism.KerbalismAssembly is null)
-                {
-                    string err = "";
-                    resHandler.UpdateModuleResourceInputs(ref err, 1, 1, true, false);
-                }
-            }
-        }
-
         private void RecalculateFields()
         {
             RAAntenna.TechLevelInfo = TechLevelInfo.GetTechLevel(techLevel);

--- a/src/RealAntennasProject/ModuleRealAntenna.cs
+++ b/src/RealAntennasProject/ModuleRealAntenna.cs
@@ -29,7 +29,7 @@ namespace RealAntennas
         private int techLevel => Convert.ToInt32(TechLevel);
 
         [KSPField] private int maxTechLevel = 0;
-        [KSPField(isPersistant = true)] public float AMWTemp;    // Antenna Microwave Temperature
+        [KSPField(isPersistant = true)] private float AMWTemp;    // Antenna Microwave Temperature
         [KSPField(isPersistant = true)] public float antennaDiameter = 0;
         [KSPField(isPersistant = true)] public float referenceGain = 0;
         [KSPField(isPersistant = true)] public float referenceFrequency = 0;

--- a/src/RealAntennasProject/Physics.cs
+++ b/src/RealAntennasProject/Physics.cs
@@ -259,8 +259,10 @@ namespace RealAntennas
             //
             // P(dBW) = 10*log10(Kb*T*bandwidth) = -228.59917 + 10*log10(T*BW)
         }
+        //RA doesn't see Skopos ground stations as ground stations for whatever reason
+        //Don't directly check if something is a ground station. Instead, see if AMWTemp has been set to something other than the default value, and use it if it is.
         public static float AntennaMicrowaveTemp(RealAntenna rx) =>
-            ((rx.ParentNode as RACommNode)?.ParentBody is CelestialBody) ? rx.AMWTemp : rx.TechLevelInfo.ReceiverNoiseTemperature;
+            (rx.AMWTemp > 1) ? rx.AMWTemp : rx.TechLevelInfo.ReceiverNoiseTemperature;
 
         public static float AtmosphericTemp(RealAntenna rx, Vector3d origin)
         {


### PR DESCRIPTION
Fix RA not properly recognizing AMWTemp for Skopos (and other Antennas that aren't ground stations but have AMWTemp manually defined for whatever reason).

This probably isn't the most elegant fix. Previously RA would check if something had a defined home celestial to determine if it was a ground station and therefore should have AMWTemp manually defined. For whatever reason, this check failed on Skopos ground stations. Instead, I replaced it with a check if AMWTemp has been manually defined in the first place (if someone has defined it, they probably want RA to use it), and use the default value for the tech level otherwise.

This has had the casualty of requiring the removal of a fallback that sets AMWTemp to part temperature if AMWTemp isn't defined. This is probably fine because that's not a very accurate fallback (physical antenna temperature has very little effect on AMW temperature), and only runs in the extremely niche scenario than an antenna has neither a manually set AMWTemp or a defined Tech Level to pull default AMWTemp from (which implies there are many more things wrong with the antenna than an undefined AMWTemp)

resolves https://github.com/KSP-RO/RealAntennas/issues/14