### PR TITLE
Remove rxHome and txHome from the jobs

### DIFF
--- a/src/RealAntennasProject/Network/ConnectionDebugger.cs
+++ b/src/RealAntennasProject/Network/ConnectionDebugger.cs
@@ -2,7 +2,7 @@
 using UnityEngine;
 using Unity.Mathematics;
 using ClickThroughFix;
-
+using System.ComponentModel;
 
 namespace RealAntennas.Network
 {
@@ -72,7 +72,12 @@ namespace RealAntennas.Network
                         // Display Tx box
                         style.alignment = TextAnchor.UpperRight;
                         GUILayout.BeginVertical("Transmitter", style, GUILayout.ExpandHeight(true), GUILayout.ExpandWidth(true));
-                        GUILayout.Label($"Antenna: {data.tx.Name}");
+                        var txParentNode = data.tx.ParentNode as RACommNode;
+                        string txParentName =
+                            txParentNode?.ParentVessel?.GetDisplayName() ??
+                            txParentNode?.ParentBody?.GetDisplayName() ??
+                            "(null)";
+                        GUILayout.Label($"Antenna: {data.tx.Name} on {txParentName}");
                         GUILayout.Label($"Power: {data.txPower}dBm");
                         GUILayout.Label($"Target: {data.tx.Target}");
                         GUILayout.Label($"Position: {data.txPos.x:F0}, {data.txPos.y:F0}, {data.txPos.z:F0}");
@@ -81,7 +86,12 @@ namespace RealAntennas.Network
                         GUILayout.EndVertical();
                         // Display Rx box
                         GUILayout.BeginVertical("Receiver", style, GUILayout.ExpandHeight(true), GUILayout.ExpandWidth(true));
-                        GUILayout.Label($"Antenna: {data.rx.Name}");
+                        var rxParentNode = data.rx.ParentNode as RACommNode;
+                        string rxParentName =
+                            rxParentNode?.ParentVessel?.GetDisplayName() ??
+                            rxParentNode?.ParentBody?.GetDisplayName() ??
+                            "(null)";
+                        GUILayout.Label($"Antenna: {data.rx.Name} on {rxParentName}");
                         GUILayout.Label($"Received Power: {data.rxPower}dBm");
                         GUILayout.Label($"Target: {data.rx.Target}");
                         GUILayout.Label($"Position: {data.rxPos.x:F0}, {data.rxPos.y:F0}, {data.rxPos.z:F0}");

--- a/src/RealAntennasProject/Precompute/Jobs.cs
+++ b/src/RealAntennasProject/Precompute/Jobs.cs
@@ -37,27 +37,31 @@ namespace RealAntennas.Precompute
         {
             int4 k = pairs[index];
             CNInfo rxNode = nodes[k.y];
-            AntennaData tx = antennas[k.z];
-            AntennaData rx = antennas[k.w];
             rxPrecalcNoise[index] = antennaNoise[k.w];
             rxSurfaceNormal[index] = rxNode.surfaceNormal;
-
-            txPower[index] = tx.txPower;
-            txFreq[index] = tx.freq;
-            txGain[index] = tx.gain;
-            txBeamwidth[index] = tx.beamwidth;
-            txInAtmosphere[index] = tx.inAtmosphere;
-            txPos[index] = tx.position;
-            txDir[index] = tx.isTracking ? (float3) (rx.position - tx.position) : tx.dir;
-
-            rxFreq[index] = rx.freq;
-            rxGain[index] = rx.gain;
-            rxBeamwidth[index] = rx.beamwidth;
-            txInAtmosphere[index] = rx.inAtmosphere;
-            rxTracking[index] = rx.isTracking;
-            rxPos[index] = rx.position;
-            rxDir[index] = rx.isTracking ? (float3) (tx.position - rx.position) : rx.dir;
-            rxAMW[index] = rx.AMW;
+            {
+                AntennaData tx = antennas[k.z];
+                txPower[index] = tx.txPower;
+                txFreq[index] = tx.freq;
+                txGain[index] = tx.gain;
+                txBeamwidth[index] = tx.beamwidth;
+                txInAtmosphere[index] = tx.inAtmosphere;
+                txPos[index] = tx.position;
+                AntennaData rx = antennas[k.w];
+                txDir[index] = tx.isTracking ? (float3) (rx.position - tx.position) : tx.dir;
+            }
+            {
+              AntennaData rx = antennas[k.w];
+              rxFreq[index] = rx.freq;
+              rxGain[index] = rx.gain;
+              rxBeamwidth[index] = rx.beamwidth;
+              rxInAtmosphere[index] = rx.inAtmosphere;
+              rxTracking[index] = rx.isTracking;
+              rxPos[index] = rx.position;
+              rxAMW[index] = rx.AMW;
+              AntennaData tx = antennas[k.z];
+              rxDir[index] = rx.isTracking ? (float3) (tx.position - rx.position) : rx.dir;
+            }
         }
     }
 

--- a/src/RealAntennasProject/Precompute/Precompute.cs
+++ b/src/RealAntennasProject/Precompute/Precompute.cs
@@ -13,7 +13,7 @@ namespace RealAntennas.Precompute
         internal float freq;
         internal float gain;
         internal float beamwidth;
-        internal bool isHome;
+        internal bool inAtmosphere;
         internal bool isTracking;
         internal double3 position;
         internal float3 dir;
@@ -76,14 +76,14 @@ namespace RealAntennas.Precompute
         private NativeArray<float> txFreq;
         private NativeArray<float> txGain;
         private NativeArray<float> txBeamwidth;
-        private NativeArray<bool> txHome;
+        private NativeArray<bool> txInAtmosphere;
         private NativeArray<double3> txPos;
         private NativeArray<float3> txDir;
 
         private NativeArray<float> rxFreq;
         private NativeArray<float> rxGain;
         private NativeArray<float> rxBeamwidth;
-        private NativeArray<bool> rxHome;
+        private NativeArray<bool> rxInAtmosphere;
         private NativeArray<bool> rxTracking;
         private NativeArray<double3> rxPos;
         private NativeArray<float3> rxDir;
@@ -223,14 +223,14 @@ namespace RealAntennas.Precompute
             txFreq = new NativeArray<float>(allAntennaPairs.Length, Allocator.TempJob);
             txGain = new NativeArray<float>(allAntennaPairs.Length, Allocator.TempJob);
             txBeamwidth = new NativeArray<float>(allAntennaPairs.Length, Allocator.TempJob);
-            txHome = new NativeArray<bool>(allAntennaPairs.Length, Allocator.TempJob);
+            txInAtmosphere = new NativeArray<bool>(allAntennaPairs.Length, Allocator.TempJob);
             txPos = new NativeArray<double3>(allAntennaPairs.Length, Allocator.TempJob);
             txDir = new NativeArray<float3>(allAntennaPairs.Length, Allocator.TempJob);
 
             rxFreq = new NativeArray<float>(allAntennaPairs.Length, Allocator.TempJob);
             rxGain = new NativeArray<float>(allAntennaPairs.Length, Allocator.TempJob);
             rxBeamwidth = new NativeArray<float>(allAntennaPairs.Length, Allocator.TempJob);
-            rxHome = new NativeArray<bool>(allAntennaPairs.Length, Allocator.TempJob);
+            rxInAtmosphere = new NativeArray<bool>(allAntennaPairs.Length, Allocator.TempJob);
             rxTracking = new NativeArray<bool>(allAntennaPairs.Length, Allocator.TempJob);
             rxPos = new NativeArray<double3>(allAntennaPairs.Length, Allocator.TempJob);
             rxDir = new NativeArray<float3>(allAntennaPairs.Length, Allocator.TempJob);
@@ -252,8 +252,8 @@ namespace RealAntennas.Precompute
                 rxGain = rxGain,
                 txBeamwidth = txBeamwidth,
                 rxBeamwidth = rxBeamwidth,
-                txHome = txHome,
-                rxHome = rxHome,
+                txInAtmosphere = txInAtmosphere,
+                rxInAtmosphere = rxInAtmosphere,
                 rxTracking = rxTracking,
                 txFreq = txFreq,
                 rxFreq = rxFreq,
@@ -344,7 +344,7 @@ namespace RealAntennas.Precompute
                 txPos = txPos,
                 rxPos = rxPos,
                 rxFreq = rxFreq,
-                rxHome = rxHome,
+                rxInAtmosphere = rxInAtmosphere,
                 rxSurfaceNormal = rxSurfaceNormal,
                 atmoNoise = atmosphereNoise,
                 elevation = antennaElevation,
@@ -615,14 +615,14 @@ namespace RealAntennas.Precompute
             txFreq.Dispose();
             txGain.Dispose();
             txBeamwidth.Dispose();
-            txHome.Dispose();
+            txInAtmosphere.Dispose();
             txPos.Dispose();
             txDir.Dispose();
 
             rxFreq.Dispose();
             rxGain.Dispose();
             rxBeamwidth.Dispose();
-            rxHome.Dispose();
+            rxInAtmosphere.Dispose();
             rxTracking.Dispose();
             rxPos.Dispose();
             rxDir.Dispose();
@@ -732,7 +732,11 @@ namespace RealAntennas.Precompute
                             freq = ra.Frequency,
                             gain = ra.Gain,
                             beamwidth = ra.Beamwidth,
-                            isHome = node.isHome,
+                            // TODO(egg): We could also say apply that to a
+                            // ParentVessel deep enough in the atmosphere.
+                            // It might make sense to take the altitude into
+                            // account eventually.
+                            inAtmosphere = node.ParentBody != null,
                             isTracking = ra.IsTracking,
                             AMW = Physics.AntennaMicrowaveTemp(ra),
                             encoder = new Encoder(ra.Encoder),

--- a/src/RealAntennasProject/RealAntenna.cs
+++ b/src/RealAntennasProject/RealAntenna.cs
@@ -28,7 +28,7 @@ namespace RealAntennas
         public virtual float AMWTemp { get; set; }
         public virtual float Beamwidth => Physics.Beamwidth(Gain);
 
-        public Antenna.Encoder Encoder => Antenna.Encoder.GetFromTechLevel(TechLevelInfo.Level); 
+        public Antenna.Encoder Encoder => Antenna.Encoder.GetFromTechLevel(TechLevelInfo.Level);
         public virtual float RequiredCI => Encoder.RequiredEbN0;
 
         public ModuleRealAntenna Parent { get; internal set; }
@@ -38,6 +38,8 @@ namespace RealAntennas
         public Vector3d PrecisePosition => ParentNode.precisePosition;
         public Vector3d TransformPosition => ParentNode.position;
         public virtual AntennaShape Shape => Gain <= Physics.MaxOmniGain ? AntennaShape.Omni : AntennaShape.Dish;
+        // Whether the antenna is a dish considered to be tracking everything at
+        // once. This is typically used for ground stations.
         public bool IsTracking => Shape != AntennaShape.Omni && Target == null;
         public virtual bool CanTarget => Shape != AntennaShape.Omni && !IsTracking;
         public Vector3 ToTarget => (CanTarget && Target != null) ? (Vector3) (Target.transform.position - Position) : Vector3.zero;


### PR DESCRIPTION
use [tr]xIsTracking or [tr]xInAtmosphere as appropriate.

Fix #38.