### PR TITLE
Allow encoders to be manually defined by ground stations

### DIFF
--- a/src/RealAntennasProject/Antenna/Encoder.cs
+++ b/src/RealAntennasProject/Antenna/Encoder.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace RealAntennas.Antenna
@@ -30,6 +31,10 @@ namespace RealAntennas.Antenna
 
         public Encoder BestMatching(in Encoder other) => TechLevel > other.TechLevel ? other : this;
         public static Encoder BestMatching(in Encoder a, in Encoder b) => a.BestMatching(b);
+        public static Encoder Get(string name, int level)
+        {
+            return string.IsNullOrEmpty(name) || !All.TryGetValue(name, out Encoder encoder) ? Encoder.GetFromTechLevel(level) : encoder;
+        }
         public static Encoder GetFromTechLevel(int level)
         {
             Encoder best = null;

--- a/src/RealAntennasProject/Antenna/Encoder.cs
+++ b/src/RealAntennasProject/Antenna/Encoder.cs
@@ -31,9 +31,9 @@ namespace RealAntennas.Antenna
 
         public Encoder BestMatching(in Encoder other) => TechLevel > other.TechLevel ? other : this;
         public static Encoder BestMatching(in Encoder a, in Encoder b) => a.BestMatching(b);
-        public static Encoder Get(string name, int level)
+        public static Encoder GetFromName(string name)
         {
-            return string.IsNullOrEmpty(name) || !All.TryGetValue(name, out Encoder encoder) ? Encoder.GetFromTechLevel(level) : encoder;
+            return !string.IsNullOrEmpty(name) ? All[name] : null;
         }
         public static Encoder GetFromTechLevel(int level)
         {

--- a/src/RealAntennasProject/RealAntenna.cs
+++ b/src/RealAntennasProject/RealAntenna.cs
@@ -27,8 +27,9 @@ namespace RealAntennas
         public virtual double Bandwidth => DataRate;          // RF bandwidth required.
         public virtual float AMWTemp { get; set; }
         public virtual float Beamwidth => Physics.Beamwidth(Gain);
+        public string encoderOverride {  get; set; }
 
-        public Antenna.Encoder Encoder => Antenna.Encoder.GetFromTechLevel(TechLevelInfo.Level);
+        public Antenna.Encoder Encoder => Antenna.Encoder.Get(encoderOverride, TechLevelInfo.Level); 
         public virtual float RequiredCI => Encoder.RequiredEbN0;
 
         public ModuleRealAntenna Parent { get; internal set; }
@@ -96,6 +97,7 @@ namespace RealAntennas
             Parent = orig.Parent;
             ParentNode = orig.ParentNode;
             ParentSnapshot = orig.ParentSnapshot;
+            encoderOverride = orig.encoderOverride;
         }
 
         public virtual bool Compatible(RealAntenna other) => RFBand == other.RFBand;
@@ -119,6 +121,7 @@ namespace RealAntennas
                 Target = Targeting.AntennaTarget.LoadFromConfig(config.GetNode("TARGET"), this);
             else if (Shape != AntennaShape.Omni && (ParentNode == null || !ParentNode.isHome) && !(Target?.Validate() == true) && HighLogic.LoadedSceneHasPlanetarium)
                 Target = Targeting.AntennaTarget.LoadFromConfig(SetDefaultTarget(), this);
+            encoderOverride = (config.HasValue("encoderOverride")) ? config.GetValue("encoderOverride") : null;
         }
 
         public virtual void ProcessUpgrades(float tsLevel, ConfigNode node)
@@ -147,6 +150,7 @@ namespace RealAntennas
             if (config.TryGetValue("SymbolRate", ref d)) SymbolRate = d;
             if (config.TryGetValue("AMWTemp", ref f)) AMWTemp = f;
             if (config.TryGetValue("RFBand", ref s)) RFBand = Antenna.BandInfo.All[s];
+            if (config.TryGetValue("encoderOverride", ref s)) encoderOverride = s;
         }
 
         public virtual ConfigNode SetDefaultTarget()

--- a/src/RealAntennasProject/RealAntenna.cs
+++ b/src/RealAntennasProject/RealAntenna.cs
@@ -27,9 +27,9 @@ namespace RealAntennas
         public virtual double Bandwidth => DataRate;          // RF bandwidth required.
         public virtual float AMWTemp { get; set; }
         public virtual float Beamwidth => Physics.Beamwidth(Gain);
-        public string encoderOverride {  get; set; }
+        public virtual string EncoderOverride { get; set; }
 
-        public Antenna.Encoder Encoder => Antenna.Encoder.Get(encoderOverride, TechLevelInfo.Level); 
+        public Antenna.Encoder Encoder => Antenna.Encoder.GetFromName(EncoderOverride) ?? Antenna.Encoder.GetFromTechLevel(TechLevelInfo.Level);
         public virtual float RequiredCI => Encoder.RequiredEbN0;
 
         public ModuleRealAntenna Parent { get; internal set; }
@@ -97,7 +97,7 @@ namespace RealAntennas
             Parent = orig.Parent;
             ParentNode = orig.ParentNode;
             ParentSnapshot = orig.ParentSnapshot;
-            encoderOverride = orig.encoderOverride;
+            EncoderOverride = orig.EncoderOverride;
         }
 
         public virtual bool Compatible(RealAntenna other) => RFBand == other.RFBand;
@@ -121,7 +121,7 @@ namespace RealAntennas
                 Target = Targeting.AntennaTarget.LoadFromConfig(config.GetNode("TARGET"), this);
             else if (Shape != AntennaShape.Omni && (ParentNode == null || !ParentNode.isHome) && !(Target?.Validate() == true) && HighLogic.LoadedSceneHasPlanetarium)
                 Target = Targeting.AntennaTarget.LoadFromConfig(SetDefaultTarget(), this);
-            encoderOverride = (config.HasValue("encoderOverride")) ? config.GetValue("encoderOverride") : null;
+            EncoderOverride = (config.HasValue("EncoderOverride")) ? config.GetValue("EncoderOverride") : null;
         }
 
         public virtual void ProcessUpgrades(float tsLevel, ConfigNode node)
@@ -150,7 +150,7 @@ namespace RealAntennas
             if (config.TryGetValue("SymbolRate", ref d)) SymbolRate = d;
             if (config.TryGetValue("AMWTemp", ref f)) AMWTemp = f;
             if (config.TryGetValue("RFBand", ref s)) RFBand = Antenna.BandInfo.All[s];
-            if (config.TryGetValue("encoderOverride", ref s)) encoderOverride = s;
+            if (config.TryGetValue("EncoderOverride", ref s)) EncoderOverride = s;
         }
 
         public virtual ConfigNode SetDefaultTarget()


### PR DESCRIPTION
Allow encoders to be manually selected by name for ground stations. This will allow Skopos ground stations to select historically accurate encoders rather than being forced to use the default encoders included with RealAntennas.