### PR TITLE
Speed up PartModule lookups

### DIFF
--- a/src/RealAntennasProject/ModuleRealAntenna.cs
+++ b/src/RealAntennasProject/ModuleRealAntenna.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using KSPCommunityFixes;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -173,7 +174,7 @@ namespace RealAntennas
                 Events[nameof(AntennaTargetGUI)].active = false;
             }
 
-            deployableAntenna = part.FindModuleImplementing<ModuleDeployableAntenna>();
+            deployableAntenna = part.FindModuleImplementingFast<ModuleDeployableAntenna>();
 
             ApplyGameSettings();
             SetupUICallbacks();

--- a/src/RealAntennasProject/RealAntennas.csproj
+++ b/src/RealAntennasProject/RealAntennas.csproj
@@ -94,6 +94,7 @@
     <Reference Include="Assembly-CSharp" />
     <Reference Include="Assembly-CSharp-firstpass" />
     <Reference Include="ClickThroughBlocker" />
+    <Reference Include="KSPCommunityFixes" />
     <Reference Include="System" />
     <Reference Include="Unity.Burst" />
     <Reference Include="Unity.Collections" />


### PR DESCRIPTION
Achieved by using the faster method provided by KSPCF. When profiling with a 246 part vessel, the per-frame `UpdateEarly` cost went from 0.29ms to 0.13ms.

# PSA: remember to update netkan after merging and releasing this.