### PR TITLE
Multiply power draw by 1000x for stock and stock-alike systems

### DIFF
--- a/GameData/RealAntennas/RealAntennasCommNetParams.cfg
+++ b/GameData/RealAntennas/RealAntennasCommNetParams.cfg
@@ -276,6 +276,17 @@ Kopernicus:NEEDS[!Kopernicus]
     Body { name = Kerbin }
 }
 
+//increase power draw by 1000x (might not be enough, tune as needed) for more stock-alike performance
+//leave idle power alone, stock doesn't even have idle power
+@RealAntennasCommNetParams:FOR[RealAntennas]:NEEDS[!RealSolarSystem]
+{
+    @TechLevelInfo,*
+    {
+        @PowerEfficiency /= 1000
+    }
+}
+
+
 @Kopernicus:HAS[@Body[Kerbin]]:FIRST
 {
     @Body[Kerbin]


### PR DESCRIPTION
Multiply power draw by 1000x for stock and stock-alike systems. Probably needs some balancing, but gets antenna power draw into the kilowatt-range instead of watt-range, similar to stock commnet system.