### PR TITLE
Added RA configuration for some antennas, and modified antenna of NFE

### DIFF
--- a/GameData/RealAntennas/Parts/Benjee10_Orion.cfg
+++ b/GameData/RealAntennas/Parts/Benjee10_Orion.cfg
@@ -1,0 +1,6 @@
+// OR-OCS Optical Communications System
+@PART[benjee10_orion_opticalComms]:HAS[!MODULE[ModuleRealAntenna]]:NEEDS[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter],* {}
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 1.8 }
+}

--- a/GameData/RealAntennas/Parts/Benjee10_shuttleOrbiter.cfg
+++ b/GameData/RealAntennas/Parts/Benjee10_shuttleOrbiter.cfg
@@ -1,0 +1,6 @@
+// OV-100 Ku Band Antenna
+@PART[benjee10_shuttle_kuBand]:HAS[!MODULE[ModuleRealAntenna]]:NEEDS[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter],* {}
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 1.2 }
+}

--- a/GameData/RealAntennas/Parts/NFE_CAE_RTREDEV.cfg
+++ b/GameData/RealAntennas/Parts/NFE_CAE_RTREDEV.cfg
@@ -188,7 +188,7 @@
 @PART[nfex-antenna-feeder-direct-1]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
 {
 	!MODULE[ModuleDataTransmitter] {}
-	%MODULE[ModuleRealAntenna]{	%antennaDiameter = 0.15}	//horns don't really act like dishes but close enough
+	%MODULE[ModuleRealAntenna]{	%antennaDiameter = 0.06}	//horns don't really act like dishes but close enough
 }
 
 //F-RA Relay Antenna Feed

--- a/GameData/RealAntennas/Parts/NFE_CAE_RTREDEV.cfg
+++ b/GameData/RealAntennas/Parts/NFE_CAE_RTREDEV.cfg
@@ -188,7 +188,7 @@
 @PART[nfex-antenna-feeder-direct-1]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
 {
 	!MODULE[ModuleDataTransmitter] {}
-	%MODULE[ModuleRealAntenna]{	%antennaDiameter = 0.06}	//horns don't really act like dishes but close enough
+	%MODULE[ModuleRealAntenna]{	%antennaDiameter = 0.15}	//horns don't really act like dishes but close enough
 }
 
 //F-RA Relay Antenna Feed

--- a/GameData/RealAntennas/Parts/SEP.cfg
+++ b/GameData/RealAntennas/Parts/SEP.cfg
@@ -1,0 +1,20 @@
+// Donnager MK-1 Expendable Main Body 
+@PART[SEP_23_SHIP_BODY_EXP]:HAS[!MODULE[ModuleRealAntenna]]:NEEDS[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter],* {}
+    %MODULE[ModuleRealAntenna] { %referenceGain = 1.25 }
+}
+
+// Donnager MK-1 Main Body
+@PART[SEP_23_SHIP_BODY]:HAS[!MODULE[ModuleRealAntenna]]:NEEDS[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter],* {}
+    %MODULE[ModuleRealAntenna] { %referenceGain = 1.25 }
+}
+
+// Laser Communication and Celestial Navigation System
+@PART[SEP_comm_Laser]:HAS[!MODULE[ModuleRealAntenna]]:NEEDS[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter],* {}
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.45 }
+}

--- a/GameData/RealAntennas/Parts/SPEX.cfg
+++ b/GameData/RealAntennas/Parts/SPEX.cfg
@@ -1,0 +1,6 @@
+// PPD-24 'Panorama' Observation Module
+@PART[sspx-observation-25-1]:HAS[!MODULE[ModuleRealAntenna]]:NEEDS[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter],* {}
+    %MODULE[ModuleRealAntenna] { %referenceGain = 0.5 }
+}

--- a/GameData/RealAntennas/Parts/Stock.cfg
+++ b/GameData/RealAntennas/Parts/Stock.cfg
@@ -1,0 +1,13 @@
+// SM-25 Service Module (From MakingHistory)
+@PART[ServiceModule25]:HAS[!MODULE[ModuleRealAntenna]]:NEEDS[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter],* {}
+    %MODULE[ModuleRealAntenna] { %referenceGain = 0.25 }
+}
+
+// Mk1 Crew Cabin (From Stock)
+@PART[MK1CrewCabin]:HAS[!MODULE[ModuleRealAntenna]]:NEEDS[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter],* {}
+    %MODULE[ModuleRealAntenna] { %referenceGain = 0.25 }
+}


### PR DESCRIPTION
1. Added support for **_Benjee10_Orion_**
2. Added support for **_Benjee10_shuttleOrbiter_**
3. Added support for **_StarshipExpansionProject_**
4. Added support for the updated **_Stockalike Station Parts Expansion Redux_**
5. RA seems to have lost some of the antenna configurations for Stock and DLC components after the update, and has been added back through the patch
6. It is noted that when the `%antennaDiameter` of the `F-DA Direct Antenna Feed` is less than 0.1, it will degenerate to the `%referenceGain` mode, and the gain may be negative. I don’t know whether it is due to the change in logic after the RA update or the change in the NFE configuration.