### PR TITLE
Manually set encoding on Soviet ground stations

### DIFF
--- a/GameData/RealAntennas/RealismOverhaul.cfg
+++ b/GameData/RealAntennas/RealismOverhaul.cfg
@@ -572,12 +572,26 @@
                             referenceFrequency = 183
                             TxPower = 76           // [1] 40 kW
                             AMWTemp = 300          // [14] Saturn-MK/MS noise 300K
+                            EncoderOverride = None // [1] coding not introduced until Venera-2 (1965). No encoder is about right for the 9.5 db C/N claimed in [6]
+                        }
+                        UPGRADE
+                        {
+                            //orthogonal coding equipment installed ~1965 for Venera 2
+                            TechLevel = 4           // Improved Comms, 1964-1966
+                            EncoderOverride = Reed-Muller 1,3 // [1] orthogonal coding introduced for Venera-2 (1965). No idea of the performance of this system, just give it Reed-Muller?
                         }
                         UPGRADE
                         {
                             //Upgraded with parts from/replaced by P-400P in 1971?
                             TechLevel = 6           // "Deep Space Comms" 1972-1975 tech node  (1971-1974)
                             TxPower = 79            // [8] 80 kW transmitter?
+                            EncoderOverride = Reed-Solomon 255/223 // [1] switch to PSK and other improvements(?) for Venera-9 (1975). Give it Reed-Solomon?
+                        }
+                        UPGRADE
+                        {
+                            //Convolutional coding equipment install ~1980 as part of Kvant-D complex [5]
+                            TechLevel = 7           // High Data Rate Comms, 1976-1980
+                            EncoderOverride = Convolutional 7, 1/2 // All we know is it was rate 1/2 and similar to "the American DSN network" [5]. Give it Convolutional 7, 1/2?
                         }
                     }
                     @Antenna:HAS[#RFBand[UHF]],*
@@ -596,14 +610,12 @@
                         {
                             TechLevel = 3           // "Interplanetary Comms" 1961-1963 tech node
                             AMWTemp = 150           // [1] Helium-cooled MASERs installed 1962?
+                            EncoderOverride = None // [1] coding not introduced until Venera-2 (1965). No encoder is about right for the 9.5 db C/N claimed in [6]
                         }
                         UPGRADE
                         {
                             TechLevel = 4           // "Improved Comms" 1964-1966 tech node
-                        }
-                        UPGRADE
-                        {
-                            TechLevel = 5           // "Advanced Comms" 1967-1971 tech node (1967-1970)
+                            EncoderOverride = Reed-Muller 1,3 // [1] orthogonal coding introduced for Venera-2 (1965). No idea of the performance of this system, just give it Reed-Muller?
                         }
                         UPGRADE
                         {
@@ -611,6 +623,7 @@
                             TechLevel = 6           // "Deep Space Comms" 1972-1975 tech node  (1971-1974)
                             TxPower = 82            // 160 kW on decimeter band?
                             AMWTemp = 82            // [7] Upgraded to 11 m^2/K
+                            EncoderOverride = Reed-Solomon 255/223 // [1] switch to PSK and other improvements(?) for Venera-9 (1975). Give it Reed-Solomon?
                         }
                         UPGRADE
                         {
@@ -621,6 +634,7 @@
                             referenceFrequency = 937    // [5] 32 cm band
                             TxPower = 83                // [5] 200KW continuous in centimeter and decimeter band
                             AMWTemp = 45                // [5] 45 K noise in decimeter band
+                            EncoderOverride = Convolutional 7, 1/2 // All we know is it was rate 1/2 and similar to "the American DSN network" [5]. Give it Convolutional 7, 1/2?
                         }
                         //ADU-1000 mostly abandoned after fall of USSR, and P-2500 doesn't appear to have recieved any upgrades since.
                     }
@@ -639,14 +653,12 @@
                         {
                             TechLevel = 3           // "Interplanetary Comms" 1961-1963 tech node
                             AMWTemp = 150           // [1] Helium-cooled MASERs installed 1962?
+                            EncoderOverride = None // [1] coding not introduced until Venera-2 (1965). No encoder is about right for the 9.5 db C/N claimed in [6]
                         }
                         UPGRADE
                         {
                             TechLevel = 4           // "Improved Comms" 1964-1966 tech node
-                        }
-                        UPGRADE
-                        {
-                            TechLevel = 5           // "Advanced Comms" 1967-1971 tech node (1967-1970)
+                            EncoderOverride = Reed-Muller 1,3 // [1] orthogonal coding introduced for Venera-2 (1965). No idea of the performance of this system, just give it Reed-Muller?
                         }
                         UPGRADE
                         {
@@ -654,6 +666,7 @@
                             TechLevel = 6           // "Deep Space Comms" 1972-1975 tech node  (1971-1974)
                             TxPower = 79            // 80 kW transmitter?
                             AMWTemp = 82            // [7] Upgraded to 11 m^2/K
+                            EncoderOverride = Reed-Solomon 255/223 // [1] switch to PSK and other improvements(?) for Venera-9 (1975). Give it Reed-Solomon?
                         }
                         UPGRADE
                         {
@@ -665,6 +678,7 @@
                             referenceFrequency = 4997   // [5] 6 cm band
                             TxPower = 83                // [5] 200KW continuous in centimeter and decimeter band
                             AMWTemp = 28                // [5] 28 K noise in 6 cm band
+                            EncoderOverride = Convolutional 7, 1/2 // All we know is it was rate 1/2 and similar to "the American DSN network" [5]. Give it Convolutional 7, 1/2?
                         }
                         //ADU-1000 mostly abandoned after fall of USSR, and P-2500 doesn't appear to have recieved any upgrades since.
                     }
@@ -680,6 +694,7 @@
                         AMWTemp = 30                // [5] 30 K noise in 3.5 cm band
                         ModulationBits = 1          // [5] Only ever used 1 bit modulation?
                         //ADU-1000 mostly abandoned after fall of USSR, and P-2500 doesn't appear to have recieved any upgrades since.
+                        EncoderOverride = Convolutional 7, 1/2 // All we know is it was rate 1/2 and similar to "the American DSN network" [5]. Give it Convolutional 7, 1/2?
                     }
                 }
                 @City2[NIP15TrackingStation],*
@@ -702,6 +717,13 @@
                             referenceGain = 13.40   // ~4 meter antenna
                             referenceFrequency = 143
                             TxPower = 50            // 100 Watts?
+                            EncoderOverride = None // [1] coding not introduced until Venera-2 (1965). No encoder is about right for the 9.5 db C/N claimed in [6]
+                        }
+                        UPGRADE
+                        {
+                            //orthogonal coding equipment installed ~1965 for Venera 2
+                            TechLevel = 4           // Improved Comms, 1964-1966
+                            EncoderOverride = Reed-Muller 1,3 // [1] orthogonal coding introduced for Venera-2 (1965). No idea of the performance of this system, just give it Reed-Muller?
                         }
                         UPGRADE
                         {
@@ -721,11 +743,30 @@
                             referenceFrequency = 183
                             TxPower = 79            // [8,9] 80 kW in decimeter band
                             AMWTemp = 300           // [14] Saturn-MK/MS noise 300K
+                            EncoderOverride = Reed-Solomon 255/223 // [1] switch to PSK and other improvements(?) for Venera-9 (1975). Give it Reed-Solomon?
+                        }
+                        UPGRADE
+                        {
+                            //Convolutional coding equipment install ~1980 as part of Kvant-D complex [5]
+                            TechLevel = 7           // High Data Rate Comms, 1976-1980
+                            EncoderOverride = Convolutional 7, 1/2 // All we know is it was rate 1/2 and similar to "the American DSN network" [5]. Give it Convolutional 7, 1/2?
                         }
                     }
                     @Antenna:HAS[#RFBand[UHF]],*
                     {
                         // Didn't actually exist prior to 71, just leave as LC-grade antenna
+                        // nerf the encoders though, so it matches the other antennas
+                        UPGRADE
+                        {
+                            TechLevel = 3           // Improved Comms, 1964-1966
+                            EncoderOverride = None // [1] coding not introduced until Venera-2 (1965). No encoder is about right for the 9.5 db C/N claimed in [6]
+                        }
+                        UPGRADE
+                        {
+                            //orthogonal coding equipment installed ~1965 for Venera 2
+                            TechLevel = 4           // Improved Comms, 1964-1966
+                            EncoderOverride = Reed-Muller 1,3 // [1] orthogonal coding introduced for Venera-2 (1965). No idea of the performance of this system, just give it Reed-Muller?
+                        }
                         UPGRADE
                         {
                             // P-400 32-meter antenna of Saturn-MSD complex, operational 1971?
@@ -734,6 +775,7 @@
                             referenceFrequency = 183
                             TxPower = 79            // [8,9] 80 kW in decimeter band
                             AMWTemp = 300           // [14] Saturn-MK/MS noise 300K
+                            EncoderOverride = Reed-Solomon 255/223 // [1] switch to PSK and other improvements(?) for Venera-9 (1975). Give it Reed-Solomon?
                         }
                         UPGRADE
                         {
@@ -744,6 +786,7 @@
                             referenceFrequency = 937    // [5] 32 cm band
                             TxPower = 83                // [5] 200KW continuous in centimeter and decimeter band
                             AMWTemp = 45                // [5] 45 K noise in decimeter band
+                            EncoderOverride = Convolutional 7, 1/2 // All we know is it was rate 1/2 and similar to "the American DSN network" [5]. Give it Convolutional 7, 1/2?
                         }
                         //ADU-1000 mostly abandoned after fall of USSR, and P-2500 doesn't appear to have recieved any upgrades since.
                     }
@@ -758,7 +801,14 @@
                         RFBand = S                  // close enough
                         AMWTemp = 300               // [14] Saturn-MK/MS noise 300K
                         ModulationBits = 1
+                        EncoderOverride = Reed-Solomon 255/223 // [1] switch to PSK and other improvements(?) for Venera-9 (1975). Give it Reed-Solomon?
 
+                        UPGRADE
+                        {
+                            //Convolutional coding equipment install ~1980 as part of Kvant-D complex [5]
+                            TechLevel = 7           // High Data Rate Comms, 1976-1980
+                            EncoderOverride = Convolutional 7, 1/2 // All we know is it was rate 1/2 and similar to "the American DSN network" [5]. Give it Convolutional 7, 1/2?
+                        }
                         UPGRADE
                         {
                             // Construction of P-2500 (RT-70) radio telescope.
@@ -782,6 +832,7 @@
                         RFBand = X                  // close enough
                         AMWTemp = 30                // [5] 30 K noise in 3.5 cm band
                         ModulationBits = 1          // [5] Only ever used 1 bit modulation?
+                        EncoderOverride = Convolutional 7, 1/2 // All we know is it was rate 1/2 and similar to "the American DSN network" [5]. Give it Convolutional 7, 1/2?
                         //P-2500 doesn't appear to have recieved any upgrades since fall of USSR
                     }
                 }
@@ -794,7 +845,7 @@
                     // Kvant-DM Complex, 2x P-200P, built 1985. Operates in UHF
                     @Antenna:HAS[#RFBand[VHF]],*
                     {
-                    // Didn't actually exist prior to 63, just leave as LC-grade antenna
+                        // Didn't actually exist prior to 63, just leave as LC-grade antenna
                         UPGRADE
                         {
                             // [10] Zarya VHF (143 MHz) station, built for Vostok-6, operational 1963?
@@ -804,6 +855,13 @@
                             referenceGain = 13.40   // ~4 meter antenna
                             referenceFrequency = 143
                             TxPower = 50            // 100 Watts?
+                            EncoderOverride = None // [1] coding not introduced until Venera-2 (1965). No encoder is about right for the 9.5 db C/N claimed in [6]
+                        }
+                        UPGRADE
+                        {
+                            //orthogonal coding equipment installed ~1965 for Venera 2
+                            TechLevel = 4           // Improved Comms, 1964-1966
+                            EncoderOverride = Reed-Muller 1,3 // [1] orthogonal coding introduced for Venera-2 (1965). No idea of the performance of this system, just give it Reed-Muller?
                         }
                         UPGRADE
                         {
@@ -814,10 +872,33 @@
                             referenceGain = 21.24   // ~8.5 meter equivalent?
                             referenceFrequency = 166
                         }
+                        UPGRADE
+                        {
+                            TechLevel = 6           // "Deep Space Comms" 1972-1975 tech node  (1971-1974)
+                            EncoderOverride = Reed-Solomon 255/223 // [1] switch to PSK and other improvements(?) for Venera-9 (1975). Give it Reed-Solomon?
+                        }
+                        UPGRADE
+                        {
+                            //Convolutional coding equipment install ~1980 as part of Kvant-D complex [5]
+                            TechLevel = 7           // High Data Rate Comms, 1976-1980
+                            EncoderOverride = Convolutional 7, 1/2 // All we know is it was rate 1/2 and similar to "the American DSN network" [5]. Give it Convolutional 7, 1/2?
+                        }
                     }
                     @Antenna:HAS[#RFBand[UHF]],*
                     {
                         // Didn't actually exist prior to 71, just leave as LC-grade antenna
+                        // nerf the encoders though, so it matches the other antennas
+                        UPGRADE
+                        {
+                            TechLevel = 3           // Improved Comms, 1964-1966
+                            EncoderOverride = None // [1] coding not introduced until Venera-2 (1965). No encoder is about right for the 9.5 db C/N claimed in [6]
+                        }
+                        UPGRADE
+                        {
+                            //orthogonal coding equipment installed ~1965 for Venera 2
+                            TechLevel = 4           // Improved Comms, 1964-1966
+                            EncoderOverride = Reed-Muller 1,3 // [1] orthogonal coding introduced for Venera-2 (1965). No idea of the performance of this system, just give it Reed-Muller?
+                        }
                         UPGRADE
                         {
                             // P-200P 25-meter antenna of Saturn-MS complex, operational 1971?
@@ -828,6 +909,13 @@
                             referenceFrequency = 937
                             TxPower = 76            // [8,9] 40 kW in decimeter band
                             AMWTemp = 300           // [14] Saturn-MK/MS noise 300K
+                            EncoderOverride = Reed-Solomon 255/223 // [1] switch to PSK and other improvements(?) for Venera-9 (1975). Give it Reed-Solomon?
+                        }
+                        UPGRADE
+                        {
+                            //Convolutional coding equipment install ~1980 as part of Kvant-D complex [5]
+                            TechLevel = 7           // High Data Rate Comms, 1976-1980
+                            EncoderOverride = Convolutional 7, 1/2 // All we know is it was rate 1/2 and similar to "the American DSN network" [5]. Give it Convolutional 7, 1/2?
                         }
                     }
                     Antenna
@@ -841,6 +929,7 @@
                         RFBand = S                  // close enough
                         AMWTemp = 373               // [13] 373 K noise
                         ModulationBits = 1          // Only ever used 1 bit modulation?
+                        EncoderOverride = Convolutional 7, 1/2 // All we know is it was rate 1/2 and similar to "the American DSN network" [5]. Give it Convolutional 7, 1/2?
                     }
                     Antenna
                     {
@@ -853,6 +942,7 @@
                         RFBand = X
                         AMWTemp = 373               // 373 K noise?
                         ModulationBits = 2          // Modern high-speed downlink
+                        //don't mess with encoders, this is post-soviet COTS stuff mostly
                     }
                 }
                 //NEN/STDN stations


### PR DESCRIPTION
Manually set encoding on soviet ground stations, somewhat shrinking the early advantage they have over the DSN.

Soviet ground stations don't receive any encoding until tech level 4 (previously at level 3). This means Soviet ground stations at TL3 are at a ~3.5 db noise disadvantage to DSN stations, partially offsetting the 8 db gain advantage of Evpatoria.

Soviet stations receive Reed-Muller 1,3 coding at TL4 (normally TL3)
Soviet stations receive Reed-Solomon 255/223 coding at TL6 (normally TL5)
Soviet stations receive Convolutional 7, 1/2 coding at TL7 (normally TL6)
Soviet stations (other than Shchelkovo) don't receive Concatenated or Turbo coding