### PR TITLE
Lower TL restriction on Lat/Lon pointing

### DIFF
--- a/GameData/RealAntennas/RealismOverhaul.cfg
+++ b/GameData/RealAntennas/RealismOverhaul.cfg
@@ -27,7 +27,7 @@
     %minRelayTL = 2
     @TargetingMode[Vessel] { %techLevel = 2 }
     @TargetingMode[BodyCenter] { %techLevel = 0 }
-    @TargetingMode[BodyLatLonAlt] { %techLevel = 4 }
+    @TargetingMode[BodyLatLonAlt] { %techLevel = 3 }
     @TargetingMode[AzEl] { %techLevel = 0 }
     @TargetingMode[OrbitRelative] { %techLevel = 2 }
 


### PR DESCRIPTION
Since we don't currently have any way to actually check if a craft is stabilized to allow pointing (and there are many ways to despin an antenna anyway), just unlock Lat/Lon targeting mode at TL3 to make Skopos contracts easier.