### PR TITLE
Remove home world from planner body presets

### DIFF
--- a/src/RealAntennasProject/PlannerGUI.cs
+++ b/src/RealAntennasProject/PlannerGUI.cs
@@ -132,11 +132,10 @@ namespace RealAntennas
             GUILayout.EndHorizontal();
             GUILayout.EndVertical();
 
-            var home = Planetarium.fetch.Home;
             var bodyList = new List<CelestialBody> { Planetarium.fetch.Sun };
             bodyList.AddRange(Planetarium.fetch.Home.orbitingBodies);
             bodyList.AddRange(Planetarium.fetch.Sun.orbitingBodies);
-            bodyList = bodyList.Where(b => b != home).ToList(); // remove homeworld
+            bodyList = bodyList.Where(b => b != Planetarium.fetch.Home).ToList(); // remove homeworld
             var bodyNames = bodyList.Select(b => b.name).ToArray();
             if (bodyIndex >= bodyList.Count) bodyIndex = 0;
 

--- a/src/RealAntennasProject/PlannerGUI.cs
+++ b/src/RealAntennasProject/PlannerGUI.cs
@@ -132,11 +132,13 @@ namespace RealAntennas
             GUILayout.EndHorizontal();
             GUILayout.EndVertical();
 
+            var home = Planetarium.fetch.Home;
             var bodyList = new List<CelestialBody> { Planetarium.fetch.Sun };
             bodyList.AddRange(Planetarium.fetch.Home.orbitingBodies);
             bodyList.AddRange(Planetarium.fetch.Sun.orbitingBodies);
-            var bodyNames = (from CelestialBody body in bodyList
-                             select body.name).ToArray();
+            bodyList = bodyList.Where(b => b != home).ToList(); // remove homeworld
+            var bodyNames = bodyList.Select(b => b.name).ToArray();
+            if (bodyIndex >= bodyList.Count) bodyIndex = 0;
 
             GUILayout.BeginVertical("Remote Body Presets", boxStyle);
             GUILayout.Space(SPACING);
@@ -144,7 +146,7 @@ namespace RealAntennas
             bodyIndex = GUILayout.SelectionGrid(bodyIndex, bodyNames, 3);
             if (bodyIndex != prev)
             {
-                var body = bodyIndex < bodyList.Count ? bodyList[bodyIndex] : bodyList.First();
+                var body = bodyList[bodyIndex];
                 MinMaxDistance(body, out distanceMin, out distanceMax);
                 ConvertDistance(distanceMax, out double tMax, out dMaxMultIndex);
                 ConvertDistance(distanceMin, out double tMin, out dMinMultIndex);


### PR DESCRIPTION
Fix https://github.com/KSP-RO/RealAntennas/issues/2 (and https://github.com/DRVeyl/RealAntennas/issues/99)

The "Earth" preset would previously give very strange values due to it being the home world. Since there isn't really any time when you would to pick Earth to check the distance away from...Earth, I've just removed it.

Previous:
![image](https://github.com/user-attachments/assets/542eed9a-5b26-4825-9971-1747b2e43b0d)

Fixed:
![image](https://github.com/user-attachments/assets/22d93d6a-90db-4b85-be26-e8232dda72db)
