### PR TITLE
Only multiply power draw for stock if RO and RSS are not installed

### DIFF
--- a/GameData/RealAntennas/RealAntennasCommNetParams.cfg
+++ b/GameData/RealAntennas/RealAntennasCommNetParams.cfg
@@ -278,7 +278,7 @@ Kopernicus:NEEDS[!Kopernicus]
 
 //increase power draw by 1000x (might not be enough, tune as needed) for more stock-alike performance
 //leave idle power alone, stock doesn't even have idle power
-@RealAntennasCommNetParams:FOR[RealAntennas]:NEEDS[!RealSolarSystem]
+@RealAntennasCommNetParams:FOR[RealAntennas]:NEEDS[!RealSolarSystem,!RealismOverhaul]
 {
     @TechLevelInfo,*
     {


### PR DESCRIPTION
[Relevant](https://github.com/KSP-RO/RealAntennas/pull/50#issuecomment-2867846725)

This especially allows for RSS scale systems like Sol that use RO to not get hurt by the nerf.

I'm still not totally sure if this should be RSS and RO, or just RO. I went with both to be safe, but perhaps someone can present a valid reason why it should be only RO.