### PR TITLE
Antenna Targeting UX Improvements

### DIFF
--- a/src/RealAntennasProject/PlannerGUI.cs
+++ b/src/RealAntennasProject/PlannerGUI.cs
@@ -132,11 +132,10 @@ namespace RealAntennas
             GUILayout.EndHorizontal();
             GUILayout.EndVertical();
 
-            var home = Planetarium.fetch.Home;
             var bodyList = new List<CelestialBody> { Planetarium.fetch.Sun };
             bodyList.AddRange(Planetarium.fetch.Home.orbitingBodies);
             bodyList.AddRange(Planetarium.fetch.Sun.orbitingBodies);
-            bodyList = bodyList.Where(b => b != home).ToList(); // remove homeworld
+            bodyList = bodyList.Where(b => b != Planetarium.fetch.Home).ToList(); // remove homeworld
             var bodyNames = bodyList.Select(b => b.name).ToArray();
             if (bodyIndex >= bodyList.Count) bodyIndex = 0;
 

--- a/src/RealAntennasProject/PlannerGUI.cs
+++ b/src/RealAntennasProject/PlannerGUI.cs
@@ -132,11 +132,13 @@ namespace RealAntennas
             GUILayout.EndHorizontal();
             GUILayout.EndVertical();
 
+            var home = Planetarium.fetch.Home;
             var bodyList = new List<CelestialBody> { Planetarium.fetch.Sun };
             bodyList.AddRange(Planetarium.fetch.Home.orbitingBodies);
             bodyList.AddRange(Planetarium.fetch.Sun.orbitingBodies);
-            var bodyNames = (from CelestialBody body in bodyList
-                             select body.name).ToArray();
+            bodyList = bodyList.Where(b => b != home).ToList(); // remove homeworld
+            var bodyNames = bodyList.Select(b => b.name).ToArray();
+            if (bodyIndex >= bodyList.Count) bodyIndex = 0;
 
             GUILayout.BeginVertical("Remote Body Presets", boxStyle);
             GUILayout.Space(SPACING);
@@ -144,7 +146,7 @@ namespace RealAntennas
             bodyIndex = GUILayout.SelectionGrid(bodyIndex, bodyNames, 3);
             if (bodyIndex != prev)
             {
-                var body = bodyIndex < bodyList.Count ? bodyList[bodyIndex] : bodyList.First();
+                var body = bodyList[bodyIndex];
                 MinMaxDistance(body, out distanceMin, out distanceMax);
                 ConvertDistance(distanceMax, out double tMax, out dMaxMultIndex);
                 ConvertDistance(distanceMin, out double tMin, out dMinMultIndex);

--- a/src/RealAntennasProject/Targeting/AntennaTarget.cs
+++ b/src/RealAntennasProject/Targeting/AntennaTarget.cs
@@ -33,7 +33,9 @@ namespace RealAntennas.Targeting
         }
         public virtual void Awake()
         {
+#if ENABLE_PROFILER
             Debug.Log("AntennaTarget.Awake()");
+#endif
         }
 
         public virtual void FixedUpdate()

--- a/src/RealAntennasProject/Targeting/AntennaTarget.cs
+++ b/src/RealAntennasProject/Targeting/AntennaTarget.cs
@@ -33,9 +33,6 @@ namespace RealAntennas.Targeting
         }
         public virtual void Awake()
         {
-#if ENABLE_PROFILER
-            Debug.Log("AntennaTarget.Awake()");
-#endif
         }
 
         public virtual void FixedUpdate()

--- a/src/RealAntennasProject/Targeting/AntennaTargetGUI.cs
+++ b/src/RealAntennasProject/Targeting/AntennaTargetGUI.cs
@@ -118,9 +118,9 @@ namespace RealAntennas.Targeting
                 GUILayout.BeginVertical();
                 GUILayout.BeginHorizontal();
                 GUILayout.Label("Lat");
-                sLat = GUILayout.TextField(sLat, 10);
+                sLat = GUILayout.TextField(sLat, 6);
                 GUILayout.Label("Lon");
-                sLon = GUILayout.TextField(sLon, 10);
+                sLon = GUILayout.TextField(sLon, 6);
                 GUILayout.Label("Alt");
                 sAlt = GUILayout.TextField(sAlt, 15);
                 GUILayout.EndHorizontal();
@@ -152,9 +152,9 @@ namespace RealAntennas.Targeting
             {
                 GUILayout.BeginHorizontal();
                 GUILayout.Label("Azimuth");
-                sAzimuth = GUILayout.TextField(sAzimuth, 10);
+                sAzimuth = GUILayout.TextField(sAzimuth, 7);
                 GUILayout.Label("Elevation");
-                sElevation = GUILayout.TextField(sElevation, 10);
+                sElevation = GUILayout.TextField(sElevation, 6);
                 GUILayout.EndHorizontal();
                 if (GUILayout.Button("Apply"))
                 {
@@ -177,9 +177,9 @@ namespace RealAntennas.Targeting
             {
                 GUILayout.BeginHorizontal();
                 GUILayout.Label("Deflection");
-                sForward = GUILayout.TextField($"{deflection}", 10);
+                sForward = GUILayout.TextField($"{deflection}", 6);
                 GUILayout.Label("Elevation");
-                sElevation = GUILayout.TextField(sElevation, 10);
+                sElevation = GUILayout.TextField(sElevation, 6);
                 GUILayout.EndHorizontal();
                 float.TryParse(sForward, out deflection);
                 deflection = GUILayout.HorizontalSlider(deflection, -180, 180);

--- a/src/RealAntennasProject/Targeting/AntennaTargetGUI.cs
+++ b/src/RealAntennasProject/Targeting/AntennaTargetGUI.cs
@@ -33,7 +33,7 @@ namespace RealAntennas.Targeting
         public void OnGUI()
         {
             GUI.skin = HighLogic.Skin;
-            Window = ClickThruBlocker.GUILayoutWindow(GetHashCode(), Window, GUIDisplay, GUIName, HighLogic.Skin.window);
+            Window = ClickThruBlocker.GUILayoutWindow(GetHashCode(), Window, GUIDisplay, GUIName, HighLogic.Skin.window, GUILayout.Width(450));
         }
 
         void GUIDisplay(int windowID)
@@ -41,7 +41,7 @@ namespace RealAntennas.Targeting
             Vessel parentVessel = (antenna?.ParentNode as RACommNode)?.ParentVessel;
 
             GUILayout.BeginVertical(HighLogic.Skin.box);
-            GUILayout.Label($"Vessel: {parentVessel?.name ?? "None"}", GUILayout.Width(450));
+            GUILayout.Label($"Vessel: {parentVessel?.name ?? "None"}");
             GUILayout.Label($"Antenna: {antenna.Name}");
             GUILayout.Label($"Band: {antenna.RFBand.name}       Power: {antenna.TxPower}dBm");
             GUILayout.Label($"Target: {antenna.Target}");

--- a/src/RealAntennasProject/Targeting/AntennaTargetGUI.cs
+++ b/src/RealAntennasProject/Targeting/AntennaTargetGUI.cs
@@ -246,11 +246,7 @@ namespace RealAntennas.Targeting
         {
             List<TargetModeInfo> validModes = TargetModeInfo.ListAll.Where(x => x.techLevel <= antenna.TechLevelInfo.Level).ToList();
 
-            int start = validModes.IndexOf(targetMode);
-            int count = validModes.Count;
-            int newIndex = (start + 1) % count;
-
-            return validModes[newIndex];
+            return validModes[(validModes.IndexOf(targetMode) + 1) % validModes.Count];
         }
 
         private class RFBandComparer : IComparer<Vessel>

--- a/src/RealAntennasProject/Targeting/AntennaTargetGUI.cs
+++ b/src/RealAntennasProject/Targeting/AntennaTargetGUI.cs
@@ -244,16 +244,13 @@ namespace RealAntennas.Targeting
 
         public TargetModeInfo GetNextTargetMode()
         {
-            int start = TargetModeInfo.ListAll.IndexOf(targetMode);
-            int i = 0;
-            int maxIter = TargetModeInfo.ListAll.Count;
-            do
-            {
-                i++;
-                int ind = (start + i) % maxIter;
-                targetMode = TargetModeInfo.ListAll[ind];
-            } while (antenna.TechLevelInfo.Level < targetMode.techLevel && i <= maxIter);
-            return targetMode;
+            List<TargetModeInfo> validModes = TargetModeInfo.ListAll.Where(x => x.techLevel <= antenna.TechLevelInfo.Level).ToList();
+
+            int start = validModes.IndexOf(targetMode);
+            int count = validModes.Count;
+            int newIndex = start != -1 ? (start + 1) % count : 0;
+
+            return validModes[newIndex];
         }
 
         private class RFBandComparer : IComparer<Vessel>

--- a/src/RealAntennasProject/Targeting/AntennaTargetGUI.cs
+++ b/src/RealAntennasProject/Targeting/AntennaTargetGUI.cs
@@ -152,7 +152,7 @@ namespace RealAntennas.Targeting
             {
                 GUILayout.BeginHorizontal();
                 GUILayout.Label("Azimuth");
-                sAzimuth = GUILayout.TextField(sAzimuth, 7);
+                sAzimuth = GUILayout.TextField(sAzimuth, 6);
                 GUILayout.Label("Elevation");
                 sElevation = GUILayout.TextField(sElevation, 6);
                 GUILayout.EndHorizontal();
@@ -177,7 +177,7 @@ namespace RealAntennas.Targeting
             {
                 GUILayout.BeginHorizontal();
                 GUILayout.Label("Deflection");
-                sForward = GUILayout.TextField($"{deflection}", 6);
+                sForward = GUILayout.TextField($"{deflection}", 7);
                 GUILayout.Label("Elevation");
                 sElevation = GUILayout.TextField(sElevation, 6);
                 GUILayout.EndHorizontal();

--- a/src/RealAntennasProject/Targeting/AntennaTargetGUI.cs
+++ b/src/RealAntennasProject/Targeting/AntennaTargetGUI.cs
@@ -248,7 +248,7 @@ namespace RealAntennas.Targeting
 
             int start = validModes.IndexOf(targetMode);
             int count = validModes.Count;
-            int newIndex = start != -1 ? (start + 1) % count : 0;
+            int newIndex = (start + 1) % count;
 
             return validModes[newIndex];
         }

--- a/src/RealAntennasProject/Targeting/AntennaTargetGUI.cs
+++ b/src/RealAntennasProject/Targeting/AntennaTargetGUI.cs
@@ -26,6 +26,8 @@ namespace RealAntennas.Targeting
         {
             vessels.Clear();
             vessels.AddRange(FlightGlobals.Vessels);
+            if (antenna.TechLevelInfo.Level < targetMode.techLevel)
+                targetMode = GetNextTargetMode();
         }
 
         public void OnGUI()
@@ -39,7 +41,7 @@ namespace RealAntennas.Targeting
             Vessel parentVessel = (antenna?.ParentNode as RACommNode)?.ParentVessel;
 
             GUILayout.BeginVertical(HighLogic.Skin.box);
-            GUILayout.Label($"Vessel: {parentVessel?.name ?? "None"}");
+            GUILayout.Label($"Vessel: {parentVessel?.name ?? "None"}", GUILayout.Width(450));
             GUILayout.Label($"Antenna: {antenna.Name}");
             GUILayout.Label($"Band: {antenna.RFBand.name}       Power: {antenna.TxPower}dBm");
             GUILayout.Label($"Target: {antenna.Target}");
@@ -202,8 +204,6 @@ namespace RealAntennas.Targeting
             GUILayout.EndVertical();
             GUILayout.Space(15);
             if (GUILayout.Button("Close")) Destroy(this);
-            if (antenna.TechLevelInfo.Level < targetMode.techLevel) // have to do this after the GUI is made to avoid issues with scaling
-                targetMode = GetNextTargetMode();
             GUI.DragWindow();
         }
 

--- a/src/RealAntennasProject/Targeting/AntennaTargetGUI.cs
+++ b/src/RealAntennasProject/Targeting/AntennaTargetGUI.cs
@@ -118,9 +118,9 @@ namespace RealAntennas.Targeting
                 GUILayout.BeginVertical();
                 GUILayout.BeginHorizontal();
                 GUILayout.Label("Lat");
-                sLat = GUILayout.TextField(sLat, 4);
+                sLat = GUILayout.TextField(sLat, 10);
                 GUILayout.Label("Lon");
-                sLon = GUILayout.TextField(sLon, 4);
+                sLon = GUILayout.TextField(sLon, 10);
                 GUILayout.Label("Alt");
                 sAlt = GUILayout.TextField(sAlt, 15);
                 GUILayout.EndHorizontal();
@@ -152,9 +152,9 @@ namespace RealAntennas.Targeting
             {
                 GUILayout.BeginHorizontal();
                 GUILayout.Label("Azimuth");
-                sAzimuth = GUILayout.TextField(sAzimuth, 4);
+                sAzimuth = GUILayout.TextField(sAzimuth, 10);
                 GUILayout.Label("Elevation");
-                sElevation = GUILayout.TextField(sElevation, 4);
+                sElevation = GUILayout.TextField(sElevation, 10);
                 GUILayout.EndHorizontal();
                 if (GUILayout.Button("Apply"))
                 {
@@ -177,9 +177,9 @@ namespace RealAntennas.Targeting
             {
                 GUILayout.BeginHorizontal();
                 GUILayout.Label("Deflection");
-                sForward = GUILayout.TextField($"{deflection}", 5);
+                sForward = GUILayout.TextField($"{deflection}", 10);
                 GUILayout.Label("Elevation");
-                sElevation = GUILayout.TextField(sElevation, 4);
+                sElevation = GUILayout.TextField(sElevation, 10);
                 GUILayout.EndHorizontal();
                 float.TryParse(sForward, out deflection);
                 deflection = GUILayout.HorizontalSlider(deflection, -180, 180);
@@ -202,6 +202,8 @@ namespace RealAntennas.Targeting
             GUILayout.EndVertical();
             GUILayout.Space(15);
             if (GUILayout.Button("Close")) Destroy(this);
+            if (antenna.TechLevelInfo.Level < targetMode.techLevel) // have to do this after the GUI is made to avoid issues with scaling
+                targetMode = GetNextTargetMode();
             GUI.DragWindow();
         }
 


### PR DESCRIPTION
Increase text field length in targeting menu to 6 characters

<img width="568" height="585" alt="image" src="https://github.com/user-attachments/assets/76c6dbb6-c910-48ad-b79f-399859e1b473" />

Additionally, fix bug where the targetMode could be set to an invalid mode the first time that the menu is opened
(for some reason this causes a harmless InvalidCastException in the Vector2 scroll view when it activates. GUI is weird)



Additionally, remove log spam from AntennaTarget.Awake()
(would get logged every time a target changed, which is just excessive)
<img width="877" height="653" alt="image" src="https://github.com/user-attachments/assets/fc4906cb-05c1-4028-9e67-267c0c8d4c59" />
