### PR TITLE
Configure sort order for ground stations in Planner GUI

### DIFF
--- a/src/RealAntennasProject/PlannerGUI.cs
+++ b/src/RealAntennasProject/PlannerGUI.cs
@@ -250,22 +250,28 @@ namespace RealAntennas
             else
             {
                 var homes = RACommNetScenario.GroundStations.Values.Where(x => x.Comm is RACommNode);
-                if (GetBestMatchingGroundStation(peer, homes) is RealAntenna bestDSNAntenna &&
-                    GUILayout.Button($"<color=orange>[Best Station]</color>: {bestDSNAntenna.ToStringShort()}", buttonStyle))
-                {
-                    antenna = bestDSNAntenna;
-                    res = true;
+                bool first = true;
+                foreach (RealAntenna ra in FilterAndSortAntennas(peer, homes)) {
+                    if (peer.Compatible(ra) && GUILayout.Button($"{(first ? "<color=orange>[Best Station]</color>: " : "")}{ra.ParentNode.displayName} {ra.ToStringShort()}", buttonStyle))
+                    {
+                        antenna = ra;
+                        res = true;
+                    }
+                    first = false;
                 }
-                foreach (Network.RACommNetHome home in homes)
-                    foreach (RealAntenna ra in home.Comm.RAAntennaList)
-                        if (peer.Compatible(ra) && GUILayout.Button($"{home.displaynodeName} {ra.ToStringShort()}", buttonStyle))
-                        {
-                            antenna = ra;
-                            res = true;
-                        }
             }
             GUILayout.EndScrollView();
             return res;
+        }
+
+        public IEnumerable<RealAntenna> FilterAndSortAntennas(RealAntenna peer, IEnumerable<Network.RACommNetHome> stations)
+        {
+            List<RealAntenna> antennas = new List<RealAntenna>();
+            foreach (Network.RACommNetHome home in stations) 
+                foreach (RealAntenna ra in home.Comm.RAAntennaList.Where(x => x.Compatible(peer))) 
+                    antennas.Add(ra);
+            
+            return antennas.OrderByDescending(ra => ra.Gain);
         }
 
         public RealAntenna GetBestMatchingGroundStation(RealAntenna peer, IEnumerable<Network.RACommNetHome> stations)

--- a/src/RealAntennasProject/PlannerGUI.cs
+++ b/src/RealAntennasProject/PlannerGUI.cs
@@ -37,13 +37,13 @@ namespace RealAntennas
         private SelectionMode fixedSelectionMode = SelectionMode.GroundStation;
         private const string sNoConnection = "<color=orange><b>(No Connection)</b></color>";
 
-        enum SortOrder { Name, RxGain, TxStrength }
+        enum SortOrder { Name, RxGain }
         private SortOrder groundStationSortOrder = SortOrder.RxGain;
         private bool ascending = false;
         private static readonly Dictionary<SortOrder, Func<RealAntenna, IComparable>> sortKeyFunctions = new Dictionary<SortOrder, Func<RealAntenna, IComparable>> {
             { SortOrder.Name, ra => ra.ParentNode.displayName },
             { SortOrder.RxGain, ra => ra.Gain },
-            { SortOrder.TxStrength, ra => ra.Gain + ra.TxPower },
+//            { SortOrder.TxStrength, ra => ra.Gain + ra.TxPower },
         };
 
         public void Start()

--- a/src/RealAntennasProject/PlannerGUI.cs
+++ b/src/RealAntennasProject/PlannerGUI.cs
@@ -40,7 +40,8 @@ namespace RealAntennas
         enum SortOrder { Name, RxGain }
         private SortOrder groundStationSortOrder = SortOrder.RxGain;
         private bool ascending = false;
-        private static readonly Dictionary<SortOrder, Func<RealAntenna, IComparable>> sortKeyFunctions = new Dictionary<SortOrder, Func<RealAntenna, IComparable>> {
+        private static readonly Dictionary<SortOrder, Func<RealAntenna, IComparable>> sortKeyFunctions = new Dictionary<SortOrder, Func<RealAntenna, IComparable>> 
+        {
             { SortOrder.Name, ra => ra.ParentNode.displayName },
             { SortOrder.RxGain, ra => ra.Gain },
 //            { SortOrder.TxStrength, ra => ra.Gain + ra.TxPower },
@@ -111,18 +112,19 @@ namespace RealAntennas
                     RequestUpdate = true;
                 }
                 GUILayout.FlexibleSpace();
+
                 GUILayout.BeginVertical();
                 GUILayout.Label("Ground Station Sort Order: ");
-                
                 GUILayout.BeginHorizontal();
-                if (GUILayout.Button(Enum.GetName(typeof(SortOrder), groundStationSortOrder))) {
+                if (GUILayout.Button(Enum.GetName(typeof(SortOrder), groundStationSortOrder))) 
                     groundStationSortOrder = (SortOrder) (((int)(groundStationSortOrder + 1)) % Enum.GetValues(typeof(SortOrder)).Length);
-                    // This is so ugly. I hate it. But it works generically even if we add more SortOrders later, so long as we stick to the 0-indexed behaviour of enums.
-                }
-                if (GUILayout.Button(ascending ? "Asc." : "Desc.")) { ascending = !ascending; }
+                    // This is so ugly. I hate it. But it works even if we add more SortOrders later, so long as we stick to the 0-indexed behaviour of enums.
+                
+                if (GUILayout.Button(ascending ? "Asc." : "Desc.")) 
+                    ascending = !ascending; 
                 GUILayout.EndHorizontal();
-
                 GUILayout.EndVertical();
+
                 GUILayout.EndHorizontal();
             }
 
@@ -290,9 +292,12 @@ namespace RealAntennas
                 foreach (RealAntenna ra in home.Comm.RAAntennaList.Where(x => x.Compatible(peer))) 
                     antennas.Add(ra);
 
-            if (ascending) {
+            if (ascending) 
+            {
                 return antennas.OrderBy(sortKeyFunctions[groundStationSortOrder]);
-            } else {
+            } 
+            else 
+            {
                 return antennas.OrderByDescending(sortKeyFunctions[groundStationSortOrder]);
             }
         }

--- a/src/RealAntennasProject/PlannerGUI.cs
+++ b/src/RealAntennasProject/PlannerGUI.cs
@@ -273,13 +273,12 @@ namespace RealAntennas
             else
             {
                 var homes = RACommNetScenario.GroundStations.Values.Where(x => x.Comm is RACommNode);
-                foreach (RealAntenna ra in FilterAndSortAntennas(peer, homes)) {
+                foreach (RealAntenna ra in FilterAndSortAntennas(peer, homes)) 
                     if (peer.Compatible(ra) && GUILayout.Button($"{ra.ParentNode.displayName} {ra.ToStringShort()}", buttonStyle))
                     {
                         antenna = ra;
                         res = true;
                     }
-                }
             }
             GUILayout.EndScrollView();
             return res;
@@ -293,13 +292,9 @@ namespace RealAntennas
                     antennas.Add(ra);
 
             if (ascending) 
-            {
                 return antennas.OrderBy(sortKeyFunctions[groundStationSortOrder]);
-            } 
             else 
-            {
                 return antennas.OrderByDescending(sortKeyFunctions[groundStationSortOrder]);
-            }
         }
 
         public RealAntenna GetBestMatchingGroundStation(RealAntenna peer, IEnumerable<Network.RACommNetHome> stations)

--- a/src/RealAntennasProject/PlannerGUI.cs
+++ b/src/RealAntennasProject/PlannerGUI.cs
@@ -115,7 +115,8 @@ namespace RealAntennas
                 GUILayout.BeginVertical();
                 GUILayout.Label("Ground Station Sort Order: ");
                 GUILayout.BeginHorizontal();
-                if (GUILayout.Button(groundStationSortOrder.ToStringCached())) {    
+                if (GUILayout.Button(groundStationSortOrder.ToStringCached())) 
+                {    
                     var values = (SortOrder[])Enum.GetValues(typeof(SortOrder));
                     int index = Array.IndexOf(values, groundStationSortOrder);
                     groundStationSortOrder = values[(index + 1) % values.Length];

--- a/src/RealAntennasProject/PlannerGUI.cs
+++ b/src/RealAntennasProject/PlannerGUI.cs
@@ -1,7 +1,7 @@
 ﻿using ClickThroughFix;
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using UniLinq;
 using UnityEngine;
 
 namespace RealAntennas
@@ -44,7 +44,6 @@ namespace RealAntennas
         {
             { SortOrder.Name, ra => ra.ParentNode.displayName },
             { SortOrder.RxGain, ra => ra.Gain },
-//            { SortOrder.TxStrength, ra => ra.Gain + ra.TxPower },
         };
 
         public void Start()
@@ -116,10 +115,11 @@ namespace RealAntennas
                 GUILayout.BeginVertical();
                 GUILayout.Label("Ground Station Sort Order: ");
                 GUILayout.BeginHorizontal();
-                if (GUILayout.Button(Enum.GetName(typeof(SortOrder), groundStationSortOrder))) 
-                    groundStationSortOrder = (SortOrder) (((int)(groundStationSortOrder + 1)) % Enum.GetValues(typeof(SortOrder)).Length);
-                    // This is so ugly. I hate it. But it works even if we add more SortOrders later, so long as we stick to the 0-indexed behaviour of enums.
-                
+                if (GUILayout.Button(groundStationSortOrder.ToStringCached())) {    
+                    var values = (SortOrder[])Enum.GetValues(typeof(SortOrder));
+                    int index = Array.IndexOf(values, groundStationSortOrder);
+                    groundStationSortOrder = values[(index + 1) % values.Length];
+                }
                 if (GUILayout.Button(ascending ? "Asc." : "Desc.")) 
                     ascending = !ascending; 
                 GUILayout.EndHorizontal();


### PR DESCRIPTION
<img width="796" height="295" alt="image" src="https://github.com/user-attachments/assets/d9ff74f4-7a11-4b92-8f87-beda01cb5d53" />

Currently supports sorting by Name, RxGain, and TxStrength (Gain + TxPower). The last one feels a little useless, I might remove it.

It also might make sense to make the first button a dropdown.