### PR TITLE
isHome =/= is a ground station, add eventvoid hook to signal when the network updates

### DIFF
--- a/GameData/RealAntennas/RealAntennasCommNetParams.cfg
+++ b/GameData/RealAntennas/RealAntennasCommNetParams.cfg
@@ -405,3 +405,25 @@ Kopernicus:NEEDS[!Kopernicus]
         }
     }
 }
+
+@Kopernicus:LAST[zRealAntennas]
+{
+    @Body[Kerbin]
+    {
+        @PQS
+        {
+            @Mods
+            {
+                @City2[*TrackingStation],*
+                {
+                    @Antenna,*
+                    {
+                        &TARGET  // 
+                        {
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/GameData/RealAntennas/RealAntennasCommNetParams.cfg
+++ b/GameData/RealAntennas/RealAntennasCommNetParams.cfg
@@ -405,25 +405,3 @@ Kopernicus:NEEDS[!Kopernicus]
         }
     }
 }
-
-@Kopernicus:LAST[zRealAntennas]
-{
-    @Body[Kerbin]
-    {
-        @PQS
-        {
-            @Mods
-            {
-                @City2[*TrackingStation],*
-                {
-                    @Antenna,*
-                    {
-                        &TARGET  // 
-                        {
-                        }
-                    }
-                }
-            }
-        }
-    }
-}

--- a/src/RealAntennasProject/Physics.cs
+++ b/src/RealAntennasProject/Physics.cs
@@ -227,8 +227,8 @@ namespace RealAntennas
             float amt = AntennaMicrowaveTemp(rx);
             float atmos = AtmosphericTemp(rx, origin);
             float cosmic = CosmicBackgroundTemp(rx, origin);
-            // Tracking antennas always point towards the peer.
-            float allbody = rx.IsTracking ? AllBodyTemps(rx, origin - rx.Position) : AllBodyTemps(rx, rx.ToTarget);
+            // Tracking antennas and omni antennas always point towards the peer.
+            float allbody = (rx.IsTracking || rx.Shape == AntennaShape.Omni) ? AllBodyTemps(rx, origin - rx.Position) : AllBodyTemps(rx, rx.ToTarget);
             float total = amt + atmos + cosmic + allbody;
             //            Debug.LogFormat("NoiseTemp: Antenna {0:F2}  Atmos: {1:F2}  Cosmic: {2:F2}  Bodies: {3:F2}  Total: {4:F2}", amt, atmos, cosmic, allbody, total);
             return total;

--- a/src/RealAntennasProject/Physics.cs
+++ b/src/RealAntennasProject/Physics.cs
@@ -227,8 +227,8 @@ namespace RealAntennas
             float amt = AntennaMicrowaveTemp(rx);
             float atmos = AtmosphericTemp(rx, origin);
             float cosmic = CosmicBackgroundTemp(rx, origin);
-            // Tracking antennas and omni antennas always point towards the peer.
-            float allbody = (rx.IsTracking || rx.Shape == AntennaShape.Omni) ? AllBodyTemps(rx, origin - rx.Position) : AllBodyTemps(rx, rx.ToTarget);
+            // Tracking antennas always point towards the peer.
+            float allbody = (rx.IsTracking) ? AllBodyTemps(rx, origin - rx.Position) : AllBodyTemps(rx, rx.ToTarget);
             float total = amt + atmos + cosmic + allbody;
             //            Debug.LogFormat("NoiseTemp: Antenna {0:F2}  Atmos: {1:F2}  Cosmic: {2:F2}  Bodies: {3:F2}  Total: {4:F2}", amt, atmos, cosmic, allbody, total);
             return total;
@@ -260,11 +260,11 @@ namespace RealAntennas
             // P(dBW) = 10*log10(Kb*T*bandwidth) = -228.59917 + 10*log10(T*BW)
         }
         public static float AntennaMicrowaveTemp(RealAntenna rx) =>
-            ((rx.ParentNode as RACommNode)?.ParentBody is CelestialBody) ? rx.AMWTemp : rx.TechLevelInfo.ReceiverNoiseTemperature;
+            (rx.ParentNode is RACommNode raNode && raNode.isGroundStation) ? rx.AMWTemp : rx.TechLevelInfo.ReceiverNoiseTemperature;
 
         public static float AtmosphericTemp(RealAntenna rx, Vector3d origin)
         {
-            if (rx.ParentNode is RACommNode rxNode && rxNode.ParentBody != null)
+            if (rx.ParentNode is RACommNode rxNode && rxNode.isGroundStation)
             {
                 Vector3d normal = rxNode.GetSurfaceNormalVector();
                 return AtmosphericTemp(new double3(rx.Position.x, rx.Position.y, rx.Position.z),
@@ -299,7 +299,7 @@ namespace RealAntennas
             float temp = 3;
             if (rx.ParentNode is RACommNode rxNode)
             {
-                Vector3d normal = (rxNode.ParentBody is CelestialBody) ? rxNode.GetSurfaceNormalVector() : Vector3d.zero;
+                Vector3d normal = rxNode.isGroundStation ? rxNode.GetSurfaceNormalVector() : Vector3d.zero;
                 Vector3d to_origin = origin - rx.Position;
                 temp = CosmicBackgroundTemp(new double3(normal.x, normal.y, normal.z),
                                             new double3(to_origin.x, to_origin.y, to_origin.z),

--- a/src/RealAntennasProject/Physics.cs
+++ b/src/RealAntennasProject/Physics.cs
@@ -227,8 +227,8 @@ namespace RealAntennas
             float amt = AntennaMicrowaveTemp(rx);
             float atmos = AtmosphericTemp(rx, origin);
             float cosmic = CosmicBackgroundTemp(rx, origin);
-            // Home Stations are directional, but treated as always pointing towards the peer.
-            float allbody = rx.ParentNode.isHome ? AllBodyTemps(rx, origin - rx.Position) : AllBodyTemps(rx, rx.ToTarget);
+            // Tracking antennas always point towards the peer.
+            float allbody = rx.IsTracking ? AllBodyTemps(rx, origin - rx.Position) : AllBodyTemps(rx, rx.ToTarget);
             float total = amt + atmos + cosmic + allbody;
             //            Debug.LogFormat("NoiseTemp: Antenna {0:F2}  Atmos: {1:F2}  Cosmic: {2:F2}  Bodies: {3:F2}  Total: {4:F2}", amt, atmos, cosmic, allbody, total);
             return total;
@@ -304,7 +304,7 @@ namespace RealAntennas
                 temp = CosmicBackgroundTemp(new double3(normal.x, normal.y, normal.z),
                                             new double3(to_origin.x, to_origin.y, to_origin.z),
                                             rx.Frequency,
-                                            rxNode.isHome);
+                                            rxNode.isGroundStation);
 
             }
             return temp;
@@ -320,7 +320,7 @@ namespace RealAntennas
                 // Note there are ~33 bodies in RSS.
                 foreach (CelestialBody body in FlightGlobals.Bodies)
                 {
-                    if (!node.isHome || !node.ParentBody.Equals(body))
+                    if (!node.isGroundStation || !node.ParentBody.Equals(body))
                     {
                         temp += BodyNoiseTemp(rx, body, rxPointing);
                     }

--- a/src/RealAntennasProject/PlannerGUI.cs
+++ b/src/RealAntennasProject/PlannerGUI.cs
@@ -349,10 +349,6 @@ namespace RealAntennas
             var defaultPos = home.GetWorldSurfacePosition(0, 0, 100);
             var defaultOffset = home.GetWorldSurfacePosition(0, 0, 1e6);
             var defaultDir = (defaultOffset - defaultPos).normalized;
-            var offset = ((fixedAntenna.ParentNode as RACommNode)?.isGroundStation ?? false) ? 1e8 : 0;
-            fixedNode.transform.SetPositionAndRotation(defaultPos + offset * defaultDir, Quaternion.identity);
-            primaryNearNode.transform.SetPositionAndRotation(defaultPos + (offset + distanceMin) * defaultDir, Quaternion.identity);
-            primaryFarNode.transform.SetPositionAndRotation(defaultPos + (offset + distanceMax) * defaultDir, Quaternion.identity);
             fixedNode.precisePosition = fixedNode.position;
             primaryNearNode.precisePosition = primaryNearNode.position;
             primaryFarNode.precisePosition = primaryFarNode.position;
@@ -364,6 +360,11 @@ namespace RealAntennas
             primaryNearNode.ParentVessel = (primaryAntenna.ParentNode as RACommNode)?.ParentVessel; // Copy this info over as well in case anything needs it.
             primaryFarNode.ParentVessel = (primaryAntenna.ParentNode as RACommNode)?.ParentVessel;
             fixedNode.ParentVessel = (fixedAntenna.ParentNode as RACommNode)?.ParentVessel;
+
+            var offset = fixedNode.isGroundStation ? 1e8 : 0;
+            fixedNode.transform.SetPositionAndRotation(defaultPos + offset * defaultDir, Quaternion.identity);
+            primaryNearNode.transform.SetPositionAndRotation(defaultPos + (offset + distanceMin) * defaultDir, Quaternion.identity);
+            primaryFarNode.transform.SetPositionAndRotation(defaultPos + (offset + distanceMax) * defaultDir, Quaternion.identity);
 
             var nodes = new List<CommNet.CommNode> { fixedNode, primaryNearNode };
             var bodies = new List<CelestialBody> { Planetarium.fetch.Home };

--- a/src/RealAntennasProject/PlannerGUI.cs
+++ b/src/RealAntennasProject/PlannerGUI.cs
@@ -349,7 +349,7 @@ namespace RealAntennas
             var defaultPos = home.GetWorldSurfacePosition(0, 0, 100);
             var defaultOffset = home.GetWorldSurfacePosition(0, 0, 1e6);
             var defaultDir = (defaultOffset - defaultPos).normalized;
-            var offset = fixedNode.isHome ? 1e8 : 0;
+            var offset = ((fixedAntenna.ParentNode as RACommNode)?.isGroundStation ?? false) ? 1e8 : 0;
             fixedNode.transform.SetPositionAndRotation(defaultPos + offset * defaultDir, Quaternion.identity);
             primaryNearNode.transform.SetPositionAndRotation(defaultPos + (offset + distanceMin) * defaultDir, Quaternion.identity);
             primaryFarNode.transform.SetPositionAndRotation(defaultPos + (offset + distanceMax) * defaultDir, Quaternion.identity);
@@ -361,6 +361,9 @@ namespace RealAntennas
             primaryNearNode.ParentBody = (primaryAntenna.ParentNode as RACommNode)?.ParentBody;
             primaryFarNode.ParentBody = (primaryAntenna.ParentNode as RACommNode)?.ParentBody;
             fixedNode.ParentBody = (fixedAntenna.ParentNode as RACommNode)?.ParentBody;
+            primaryNearNode.ParentVessel = (primaryAntenna.ParentNode as RACommNode)?.ParentVessel; // Copy this info over as well in case anything needs it.
+            primaryFarNode.ParentVessel = (primaryAntenna.ParentNode as RACommNode)?.ParentVessel;
+            fixedNode.ParentVessel = (fixedAntenna.ParentNode as RACommNode)?.ParentVessel;
 
             var nodes = new List<CommNet.CommNode> { fixedNode, primaryNearNode };
             var bodies = new List<CelestialBody> { Planetarium.fetch.Home };

--- a/src/RealAntennasProject/PlannerGUI.cs
+++ b/src/RealAntennasProject/PlannerGUI.cs
@@ -349,9 +349,6 @@ namespace RealAntennas
             var defaultPos = home.GetWorldSurfacePosition(0, 0, 100);
             var defaultOffset = home.GetWorldSurfacePosition(0, 0, 1e6);
             var defaultDir = (defaultOffset - defaultPos).normalized;
-            fixedNode.precisePosition = fixedNode.position;
-            primaryNearNode.precisePosition = primaryNearNode.position;
-            primaryFarNode.precisePosition = primaryFarNode.position;
             fixedNode.isHome = fixedAntenna.ParentNode?.isHome ?? false;
             primaryNearNode.isHome = primaryFarNode.isHome = primaryAntenna.ParentNode?.isHome ?? false;
             primaryNearNode.ParentBody = (primaryAntenna.ParentNode as RACommNode)?.ParentBody;
@@ -365,6 +362,10 @@ namespace RealAntennas
             fixedNode.transform.SetPositionAndRotation(defaultPos + offset * defaultDir, Quaternion.identity);
             primaryNearNode.transform.SetPositionAndRotation(defaultPos + (offset + distanceMin) * defaultDir, Quaternion.identity);
             primaryFarNode.transform.SetPositionAndRotation(defaultPos + (offset + distanceMax) * defaultDir, Quaternion.identity);
+
+            fixedNode.precisePosition = fixedNode.position;
+            primaryNearNode.precisePosition = primaryNearNode.position;
+            primaryFarNode.precisePosition = primaryFarNode.position;
 
             var nodes = new List<CommNet.CommNode> { fixedNode, primaryNearNode };
             var bodies = new List<CelestialBody> { Planetarium.fetch.Home };

--- a/src/RealAntennasProject/Precompute/FilteringJobs.cs
+++ b/src/RealAntennasProject/Precompute/FilteringJobs.cs
@@ -18,7 +18,7 @@ namespace RealAntennas.Precompute
             int y = pairs[index].y;
             CNInfo a = nodes[x];
             CNInfo b = nodes[y];
-            valid[index] = x != y && !(a.isHome && b.isHome) && a.canComm && b.canComm;
+            valid[index] = x != y && !(a.isGroundStation && b.isGroundStation) && a.canComm && b.canComm;
         }
     }
 

--- a/src/RealAntennasProject/Precompute/Precompute.cs
+++ b/src/RealAntennasProject/Precompute/Precompute.cs
@@ -736,7 +736,7 @@ namespace RealAntennas.Precompute
                             // ParentVessel deep enough in the atmosphere.
                             // It might make sense to take the altitude into
                             // account eventually.
-                            inAtmosphere = node.ParentBody != null,
+                            inAtmosphere = node.isGroundStation,
                             isTracking = ra.IsTracking,
                             AMW = Physics.AntennaMicrowaveTemp(ra),
                             encoder = new Encoder(ra.Encoder),

--- a/src/RealAntennasProject/Precompute/Precompute.cs
+++ b/src/RealAntennasProject/Precompute/Precompute.cs
@@ -28,7 +28,7 @@ namespace RealAntennas.Precompute
     {
         internal double3 position;
         internal double3 surfaceNormal;
-        internal bool isHome;
+        internal bool isGroundStation;
         internal bool canComm;
     }
 
@@ -682,7 +682,7 @@ namespace RealAntennas.Precompute
                     infos.Add(new CNInfo()
                     {
                         position = new double3(node.precisePosition.x, node.precisePosition.y, node.precisePosition.z),
-                        isHome = node.isHome,
+                        isGroundStation = node.isGroundStation, 
                         canComm = forceValid || node.CanComm(),
                         surfaceNormal = new double3(surfN.x, surfN.y, surfN.z),
                         //name = $"{node}",

--- a/src/RealAntennasProject/RACommNetVessel.cs
+++ b/src/RealAntennasProject/RACommNetVessel.cs
@@ -256,8 +256,8 @@ namespace RealAntennas
         }
         private void ValidateAntennaTarget(RealAntenna ra)
         {
-            if (ra.CanTarget && !(ra.Target?.Validate() == true))
-                ra.Target = Targeting.AntennaTarget.LoadFromConfig(ra.SetDefaultTarget(), ra);
+            if (ra.CanTarget && ra.Target?.Validate() != true)
+                ra.SetDefaultTarget();
         }
         public static bool DeployedUnloaded(ProtoPartSnapshot part)
         {

--- a/src/RealAntennasProject/RACommNetwork.cs
+++ b/src/RealAntennasProject/RACommNetwork.cs
@@ -22,6 +22,8 @@ namespace RealAntennas
         public List<CommNode> Nodes { get => nodes; }
         public RealAntenna DebugAntenna => connectionDebugger?.antenna;
         public Network.ConnectionDebugger connectionDebugger = null;
+        public readonly EventVoid NetworkUpdateComplete = new EventVoid("Network Rebuild Complete");
+        public double LastUpdateUT { get; private set; } = 0;
 
         public override CommNode Add(CommNode conn)
         {
@@ -164,6 +166,8 @@ namespace RealAntennas
                 PostUpdateNodes();
                 if (OnNetworkPostUpdate is Action)
                     OnNetworkPostUpdate();
+                LastUpdateUT = Planetarium.GetUniversalTime();
+                NetworkUpdateComplete.Fire();
                 tempWatch.Stop();
                 Profiler.EndSample();
                 (RACommNetScenario.Instance as RACommNetScenario).metrics.AddMeasurement("Precompute LateRebuild", PrecomputeLateWatch.Elapsed.TotalMilliseconds);

--- a/src/RealAntennasProject/RACommNode.cs
+++ b/src/RealAntennasProject/RACommNode.cs
@@ -10,6 +10,8 @@ namespace RealAntennas
         public List<RealAntenna> RAAntennaList { get; set; }
         public CelestialBody ParentBody { get; set; }
         public Vessel ParentVessel { get; set; }
+        public bool isGroundStation => !(ParentBody is null);
+        // Skopos stations have isHome set to false, hence the need for this check.
 
         public RACommNode() : base() { }
         public RACommNode(Transform t) : base(t)

--- a/src/RealAntennasProject/RACommNode.cs
+++ b/src/RealAntennasProject/RACommNode.cs
@@ -10,7 +10,7 @@ namespace RealAntennas
         public List<RealAntenna> RAAntennaList { get; set; }
         public CelestialBody ParentBody { get; set; }
         public Vessel ParentVessel { get; set; }
-        public bool isGroundStation => !(ParentBody is null);
+        public bool isGroundStation => ParentBody != null;
         // Skopos stations have isHome set to false, hence the need for this check.
 
         public RACommNode() : base() { }
@@ -33,7 +33,7 @@ namespace RealAntennas
 
         public bool CanComm()
         {
-            if (ParentBody != null) return true;
+            if (isGroundStation) return true;
             return (ParentVessel?.Connection is RACommNetVessel raCNV) && raCNV.powered && raCNV.CanComm;
         }
 

--- a/src/RealAntennasProject/RealAntenna.cs
+++ b/src/RealAntennasProject/RealAntenna.cs
@@ -121,6 +121,10 @@ namespace RealAntennas
             AMWTemp = (config.HasValue("AMWTemp")) ? float.Parse(config.GetValue("AMWTemp")) : 290f;
             if (config.HasNode("TARGET"))
                 Target = Targeting.AntennaTarget.LoadFromConfig(config.GetNode("TARGET"), this);
+            else if (ParentNode is RACommNode RANode && RANode.isGroundStation) {
+                Debug.LogFormat($"{ModTag} ground station {RANode.displayName} antenna {Name} missing TARGET node - defaulted to null");
+                Target = null;
+            }
             else if (Shape != AntennaShape.Omni && !(Target?.Validate() == true) && HighLogic.LoadedSceneHasPlanetarium)
                 Target = Targeting.AntennaTarget.LoadFromConfig(SetDefaultTarget(), this);
 
@@ -158,8 +162,6 @@ namespace RealAntennas
 
         public virtual ConfigNode SetDefaultTarget()
         {
-            if (ParentNode is RACommNode RANode && RANode.isGroundStation) 
-                return null;
             var x = new ConfigNode(Targeting.AntennaTarget.nodeName);
             x.AddValue("name", $"{Targeting.AntennaTarget.TargetMode.BodyLatLonAlt}");
             x.AddValue("bodyName", Planetarium.fetch.Home.name);

--- a/src/RealAntennasProject/RealAntenna.cs
+++ b/src/RealAntennasProject/RealAntenna.cs
@@ -121,7 +121,7 @@ namespace RealAntennas
             AMWTemp = (config.HasValue("AMWTemp")) ? float.Parse(config.GetValue("AMWTemp")) : 290f;
             if (config.HasNode("TARGET"))
                 Target = Targeting.AntennaTarget.LoadFromConfig(config.GetNode("TARGET"), this);
-            else if (Shape != AntennaShape.Omni && (ParentNode == null || !(ParentNode is RACommNode RANode && RANode.isGroundStation)) && !(Target?.Validate() == true) && HighLogic.LoadedSceneHasPlanetarium)
+            else if (Shape != AntennaShape.Omni && !(Target?.Validate() == true) && HighLogic.LoadedSceneHasPlanetarium)
                 Target = Targeting.AntennaTarget.LoadFromConfig(SetDefaultTarget(), this);
 
             EncoderOverride = (config.HasValue("EncoderOverride")) ? config.GetValue("EncoderOverride") : null;
@@ -158,6 +158,8 @@ namespace RealAntennas
 
         public virtual ConfigNode SetDefaultTarget()
         {
+            if (ParentNode is RACommNode RANode && RANode.isGroundStation) 
+                return null;
             var x = new ConfigNode(Targeting.AntennaTarget.nodeName);
             x.AddValue("name", $"{Targeting.AntennaTarget.TargetMode.BodyLatLonAlt}");
             x.AddValue("bodyName", Planetarium.fetch.Home.name);

--- a/src/RealAntennasProject/RealAntenna.cs
+++ b/src/RealAntennasProject/RealAntenna.cs
@@ -45,6 +45,8 @@ namespace RealAntennas
         public virtual bool CanTarget => Shape != AntennaShape.Omni && !IsTracking;
         public Vector3 ToTarget => (CanTarget && Target != null) ? (Vector3) (Target.transform.position - Position) : Vector3.zero;
 
+        // In the absence of a TARGET config node, antennas will target the centre of the home body.
+        // However, if the antenna belongs to a node with a ParentBody, Target will be set to null.
         private Targeting.AntennaTarget _target;
         public Targeting.AntennaTarget Target
         {
@@ -117,13 +119,9 @@ namespace RealAntennas
             TxPower = (config.HasValue("TxPower")) ? float.Parse(config.GetValue("TxPower")) : 30f;
             SymbolRate = RFBand.MaxSymbolRate(TechLevelInfo.Level);
             AMWTemp = (config.HasValue("AMWTemp")) ? float.Parse(config.GetValue("AMWTemp")) : 290f;
-            
-            // Ground stations that intend to have their antennas track all peer antennas
-            // should either have isHome set (valid science endpoint)
-            // or else have an empty TARGET node specified for each of their antennas.
             if (config.HasNode("TARGET"))
                 Target = Targeting.AntennaTarget.LoadFromConfig(config.GetNode("TARGET"), this);
-            else if (Shape != AntennaShape.Omni && (ParentNode == null || !ParentNode.isHome) && !(Target?.Validate() == true) && HighLogic.LoadedSceneHasPlanetarium)
+            else if (Shape != AntennaShape.Omni && (ParentNode == null || !(ParentNode is RACommNode RANode && RANode.isGroundStation)) && !(Target?.Validate() == true) && HighLogic.LoadedSceneHasPlanetarium)
                 Target = Targeting.AntennaTarget.LoadFromConfig(SetDefaultTarget(), this);
 
             EncoderOverride = (config.HasValue("EncoderOverride")) ? config.GetValue("EncoderOverride") : null;

--- a/src/RealAntennasProject/RealAntenna.cs
+++ b/src/RealAntennasProject/RealAntenna.cs
@@ -117,10 +117,15 @@ namespace RealAntennas
             TxPower = (config.HasValue("TxPower")) ? float.Parse(config.GetValue("TxPower")) : 30f;
             SymbolRate = RFBand.MaxSymbolRate(TechLevelInfo.Level);
             AMWTemp = (config.HasValue("AMWTemp")) ? float.Parse(config.GetValue("AMWTemp")) : 290f;
+            
+            // Ground stations that intend to have their antennas track all peer antennas
+            // should either have isHome set (valid science endpoint)
+            // or else have an empty TARGET node specified for each of their antennas.
             if (config.HasNode("TARGET"))
                 Target = Targeting.AntennaTarget.LoadFromConfig(config.GetNode("TARGET"), this);
             else if (Shape != AntennaShape.Omni && (ParentNode == null || !ParentNode.isHome) && !(Target?.Validate() == true) && HighLogic.LoadedSceneHasPlanetarium)
                 Target = Targeting.AntennaTarget.LoadFromConfig(SetDefaultTarget(), this);
+
             EncoderOverride = (config.HasValue("EncoderOverride")) ? config.GetValue("EncoderOverride") : null;
         }
 

--- a/src/RealAntennasProject/RealAntenna.cs
+++ b/src/RealAntennasProject/RealAntenna.cs
@@ -157,7 +157,6 @@ namespace RealAntennas
             if (config.TryGetValue("EncoderOverride", ref s)) EncoderOverride = s;
         }
         
-        // Returns the new target.
         public virtual void SetDefaultTarget()
         {
             if (ParentNode is RACommNode raNode && raNode.isGroundStation)

--- a/src/RealAntennasProject/RealAntenna.cs
+++ b/src/RealAntennasProject/RealAntenna.cs
@@ -158,14 +158,15 @@ namespace RealAntennas
         
         public virtual void SetDefaultTarget()
         {
-            if (ParentNode is RACommNode raNode && raNode.isGroundStation)
+            if (!(ParentNode is RACommNode raNode))
             {
+                Debug.Log($"{ModTag} {ParentNode?.displayName} is not an RA comm node but has a RealAntenna! Defaulting target for {Name} to null");
                 Target = null;
             }
+            else if (raNode.isGroundStation)
+                Target = null;
             else
             {
-                if (!(ParentNode is RACommNode))
-                    Debug.Log($"{ModTag} {ParentNode?.displayName} is not an RA comm node but has a RealAntenna! Defaulting target for {Name} to null");
                 var x = new ConfigNode(Targeting.AntennaTarget.nodeName);
                 x.AddValue("name", $"{Targeting.AntennaTarget.TargetMode.BodyLatLonAlt}");
                 x.AddValue("bodyName", Planetarium.fetch.Home.name);

--- a/src/RealAntennasProject/RealAntenna.cs
+++ b/src/RealAntennasProject/RealAntenna.cs
@@ -158,22 +158,21 @@ namespace RealAntennas
         }
         
         // Returns the new target.
-        public virtual Targeting.AntennaTarget SetDefaultTarget()
+        public virtual void SetDefaultTarget()
         {
-            if (ParentNode is RACommNode raNode)
+            if (ParentNode is RACommNode raNode && raNode.isGroundStation)
             {
-                if (raNode.isGroundStation)
-                    return Target = null;
+                Target = null;
+            }
+            else
+            {
+                if (!(ParentNode is RACommNode))
+                    Debug.Log($"{ModTag} {ParentNode?.displayName} is not an RA comm node but has a RealAntenna! Defaulting target for {Name} to null");
                 var x = new ConfigNode(Targeting.AntennaTarget.nodeName);
                 x.AddValue("name", $"{Targeting.AntennaTarget.TargetMode.BodyLatLonAlt}");
                 x.AddValue("bodyName", Planetarium.fetch.Home.name);
                 x.AddValue("latLonAlt", new Vector3(0, 0, (float)-Planetarium.fetch.Home.Radius));
-                return Target = Targeting.AntennaTarget.LoadFromConfig(x, this);
-            }
-            else
-            {
-                Debug.LogError($"{ModTag} {ParentNode.displayName} is not an RA comm node but has a RealAntenna! Defaulting target for {Name} to null");
-                return Target = null;
+                Target = Targeting.AntennaTarget.LoadFromConfig(x, this);
             }
         }
     }

--- a/src/RealAntennasProject/RealAntenna.cs
+++ b/src/RealAntennasProject/RealAntenna.cs
@@ -1,5 +1,4 @@
-﻿using CommNet;
-using System;
+﻿using System;
 using System.Linq;
 using UnityEngine;
 

--- a/src/RealAntennasProject/RealAntenna.cs
+++ b/src/RealAntennasProject/RealAntenna.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using CommNet;
+using System;
 using System.Linq;
 using UnityEngine;
 
@@ -121,12 +122,8 @@ namespace RealAntennas
             AMWTemp = (config.HasValue("AMWTemp")) ? float.Parse(config.GetValue("AMWTemp")) : 290f;
             if (config.HasNode("TARGET"))
                 Target = Targeting.AntennaTarget.LoadFromConfig(config.GetNode("TARGET"), this);
-            else if (ParentNode is RACommNode RANode && RANode.isGroundStation) {
-                Debug.LogFormat($"{ModTag} ground station {RANode.displayName} antenna {Name} missing TARGET node - defaulted to null");
-                Target = null;
-            }
-            else if (Shape != AntennaShape.Omni && !(Target?.Validate() == true) && HighLogic.LoadedSceneHasPlanetarium)
-                Target = Targeting.AntennaTarget.LoadFromConfig(SetDefaultTarget(), this);
+            else if (Shape != AntennaShape.Omni && Target?.Validate() != true && HighLogic.LoadedSceneHasPlanetarium)
+                SetDefaultTarget();
 
             EncoderOverride = (config.HasValue("EncoderOverride")) ? config.GetValue("EncoderOverride") : null;
         }
@@ -159,14 +156,25 @@ namespace RealAntennas
             if (config.TryGetValue("RFBand", ref s)) RFBand = Antenna.BandInfo.All[s];
             if (config.TryGetValue("EncoderOverride", ref s)) EncoderOverride = s;
         }
-
-        public virtual ConfigNode SetDefaultTarget()
+        
+        // Returns the new target.
+        public virtual Targeting.AntennaTarget SetDefaultTarget()
         {
-            var x = new ConfigNode(Targeting.AntennaTarget.nodeName);
-            x.AddValue("name", $"{Targeting.AntennaTarget.TargetMode.BodyLatLonAlt}");
-            x.AddValue("bodyName", Planetarium.fetch.Home.name);
-            x.AddValue("latLonAlt", new Vector3(0, 0, (float)-Planetarium.fetch.Home.Radius));
-            return x;
+            if (ParentNode is RACommNode raNode)
+            {
+                if (raNode.isGroundStation)
+                    return Target = null;
+                var x = new ConfigNode(Targeting.AntennaTarget.nodeName);
+                x.AddValue("name", $"{Targeting.AntennaTarget.TargetMode.BodyLatLonAlt}");
+                x.AddValue("bodyName", Planetarium.fetch.Home.name);
+                x.AddValue("latLonAlt", new Vector3(0, 0, (float)-Planetarium.fetch.Home.Radius));
+                return Target = Targeting.AntennaTarget.LoadFromConfig(x, this);
+            }
+            else
+            {
+                Debug.LogError($"{ModTag} {ParentNode.displayName} is not an RA comm node but has a RealAntenna! Defaulting target for {Name} to null");
+                return Target = null;
+            }
         }
     }
 }

--- a/src/RealAntennasProject/RealAntennasUI.cs
+++ b/src/RealAntennasProject/RealAntennasUI.cs
@@ -128,7 +128,7 @@ namespace RealAntennas
                 net = $"{racn}";
                 foreach (RACommNode node in racn.Nodes)
                 {
-                    if (node.isHome)
+                    if (node.isGroundStation)
                     {
                         groundStations++;
                     }

--- a/src/RealAntennasProject/Tools.cs
+++ b/src/RealAntennasProject/Tools.cs
@@ -51,7 +51,7 @@ namespace RealAntennas
         {
             RealAntenna result = null;
             double highestGain = 0;
-            foreach (RACommNode node in nodes.Where(obj => obj.isHome))
+            foreach (RACommNode node in nodes.Where(obj => obj is RACommNode raNode && raNode.isGroundStation))
             {
                 foreach (RealAntenna ra in node.RAAntennaList)
                 {


### PR DESCRIPTION
Fixes for Skopos, and the hook needed for https://github.com/mockingbirdnest/Skopos/pull/70.

This formally distinguishes between "ground stations" and "homes". Checks that appear to apply to all ground stations (and not just "homes") now check the `isGroundStation` flag, which checks if `ParentBody` is not null.

Two non-trivial usages of `CommNode.isHome` are currently left unmodified:
- `RealAntenna.LoadFromConfigNode`: I am not confident that the ParentNode is fully initialised when we call this function. 
- `RATools.HighestGainCompatibleDSNAntenna`: The function name appears to imply it is intended for "home" antennas, though it is currently unused in the code (?).

I don't think replacing the `isHome` usages in `Physics.cs` actually changed any calculations? When I checked a link with low antenna elevation and high beamwidth (GEO sat to Bering Sea ship), it had no impact on the calculated noise temperature.