### PR TITLE
Add KSPAssemblyDependency on KSPBurst

### DIFF
--- a/src/RealAntennasProject/Properties/AssemblyInfo.cs
+++ b/src/RealAntennasProject/Properties/AssemblyInfo.cs
@@ -43,3 +43,4 @@ using System.Runtime.InteropServices;
 
 [assembly: KSPAssemblyDependency("ClickThroughBlocker", 1, 8)]
 [assembly: KSPAssemblyDependency("KSPCommunityFixes", 1, 36, 0)]
+[assembly: KSPAssemblyDependency("KSPBurst", 1, 5, 5)]


### PR DESCRIPTION
This allows [KSPBurst](https://github.com/KSPModdingLibs/KSPBurst/blob/cfe869aac6bdcdeb477da50f8903a088ab5824fe/GameData/000_KSPBurst/DependencyCompat.cfg#L32-L35) to remove RealAntennas from its stopgap list