### PR TITLE
Remove references to NFEX mechanics for feeders and reflectors in part descriptions

### DIFF
--- a/GameData/RealAntennas/Parts/NFE_CAE_RTREDEV.cfg
+++ b/GameData/RealAntennas/Parts/NFE_CAE_RTREDEV.cfg
@@ -189,6 +189,7 @@
 {
 	!MODULE[ModuleDataTransmitter] {}
 	%MODULE[ModuleRealAntenna]{	%antennaDiameter = 0.06}	//horns don't really act like dishes but close enough
+	@description ^= :range on its own - pair with a large reflector to use effectively:gain: //This does not work with a reflector in RA, remove that part of the description.
 }
 
 //F-RA Relay Antenna Feed
@@ -226,3 +227,8 @@
 	%MODULE[ModuleRealAntenna]{	%referenceGain = 3}
 }
 
+//Remove info on feeder antennae from dish descriptions, doesn't apply in RA
+@PART[nfex-antenna-*]:HAS[@MODULE[ModuleRealAntenna]:HAS[#antennaDiameter]]:AFTER[RealAntennas]
+{
+	@description ^= : Useless without a feeding antenna.:: 
+}

--- a/GameData/RealAntennas/Parts/NFE_CAE_RTREDEV.cfg
+++ b/GameData/RealAntennas/Parts/NFE_CAE_RTREDEV.cfg
@@ -227,8 +227,8 @@
 	%MODULE[ModuleRealAntenna]{	%referenceGain = 3}
 }
 
-//Remove info on feeder antennae from dish descriptions, doesn't apply in RA
-@PART[nfex-antenna-*]:HAS[@MODULE[ModuleRealAntenna]:HAS[#antennaDiameter]]:AFTER[RealAntennas]
+//Remove info on feeder antennae from antenna descriptions, doesn't apply in RA
+@PART[nfex-antenna-*]:HAS[@MODULE[ModuleRealAntenna]]:LAST[RealAntennas]
 {
 	@description ^= : Useless without a feeding antenna.:: 
 }


### PR DESCRIPTION
NFE reflector descriptions say they are useless without a feeder antenna. This is untrue in RA. This PR removes that text from their descriptions.

It also makes a small edit to the horn to remove references to reflectors.