### PR TITLE
Show ground station lat/lon on map node hover

### DIFF
--- a/src/RealAntennasProject/MapUI/GroundStationSiteNode.cs
+++ b/src/RealAntennasProject/MapUI/GroundStationSiteNode.cs
@@ -29,6 +29,8 @@ namespace RealAntennas.MapUI
             if (body == null) return string.Empty;
             body.GetLatLonAlt(node.position, out double lat, out double lon, out _);
             lon = ((lon + 540d) % 360d) - 180d;
+            if (RACommNetScenario.MapUISettings?.groundStationLatLonSigned ?? false)
+                return $"{lat:F2}°, {lon:F2}°";
             return $"{Math.Abs(lat):F2}° {(lat >= 0 ? "N" : "S")}, {Math.Abs(lon):F2}° {(lon >= 0 ? "E" : "W")}";
         }
     }

--- a/src/RealAntennasProject/MapUI/GroundStationSiteNode.cs
+++ b/src/RealAntennasProject/MapUI/GroundStationSiteNode.cs
@@ -1,4 +1,5 @@
 ﻿using KSP.UI.Screens.Mapview;
+using System;
 using UnityEngine;
 
 namespace RealAntennas.MapUI
@@ -19,7 +20,16 @@ namespace RealAntennas.MapUI
         {
             data.captionLine1 = $"{node.displayName}";
             data.captionLine2 = RATools.PrettyPrint(node.RAAntennaList);
-            //data.captionLine3 = "CapLine3";
+            data.captionLine3 = FormatLatLon();
+        }
+
+        private string FormatLatLon()
+        {
+            CelestialBody body = node.ParentBody;
+            if (body == null) return string.Empty;
+            body.GetLatLonAlt(node.position, out double lat, out double lon, out _);
+            lon = ((lon + 540d) % 360d) - 180d;
+            return $"{Math.Abs(lat):F2}° {(lat >= 0 ? "N" : "S")}, {Math.Abs(lon):F2}° {(lon >= 0 ? "E" : "W")}";
         }
     }
 }

--- a/src/RealAntennasProject/MapUI/NetUIConfigurationWindow.cs
+++ b/src/RealAntennasProject/MapUI/NetUIConfigurationWindow.cs
@@ -42,6 +42,11 @@ namespace RealAntennas.MapUI
                 settings.drawCone10 = !settings.drawCone10;
             GUILayout.EndHorizontal();
 
+            GUILayout.BeginHorizontal();
+            if (GUILayout.Button($"Lat/Lon Format: {(settings.groundStationLatLonSigned ? "Signed" : "Hemisphere")}"))
+                settings.groundStationLatLonSigned = !settings.groundStationLatLonSigned;
+            GUILayout.EndHorizontal();
+
             if (MapView.fetch is MapView && MapView.MapCamera is PlanetariumCamera)
             {
                 GUILayout.BeginVertical();

--- a/src/RealAntennasProject/MapUI/Settings.cs
+++ b/src/RealAntennasProject/MapUI/Settings.cs
@@ -16,5 +16,6 @@ namespace RealAntennas.MapUI
         [Persistent] public bool drawCone3 = true;
         [Persistent] public bool drawCone10 = true;
         [Persistent] public float lineScaleWidth = 2.5f;
+        [Persistent] public bool groundStationLatLonSigned = false;
     }
 }


### PR DESCRIPTION
Populates `captionLine3` of the ground station map node with the station's latitude and longitude (e.g. `28.61° N, 80.60° W`), derived from the station's body and position. Replaces the existing commented-out `CapLine3` placeholder.

A toggle in the RA settings window switches between **Hemisphere** (`28.61° N, 80.60° W`, default) and **Signed** (`28.61°, -80.60°`).

Useful for cross-referencing stations with their config or with real-world DSN sites without leaving map view.

## Screenshot
<img width="415" height="307" alt="image" src="https://github.com/user-attachments/assets/27d9273c-0e62-4d87-be9e-cced90e2dce4" />
