### PR TITLE
Change key for groundStationSiteNodes to RACommNetHome instead of the name

### DIFF
--- a/src/RealAntennasProject/MapUI/RACommNetUI.cs
+++ b/src/RealAntennasProject/MapUI/RACommNetUI.cs
@@ -18,7 +18,7 @@ namespace RealAntennas.MapUI
         public Color color3dB = XKCDColors.BarbiePink;
         public Color color10dB = XKCDColors.Lavender;
 
-        public readonly Dictionary<string, SiteNode> groundStationSiteNodes = new Dictionary<string, SiteNode>();
+        public readonly Dictionary<RACommNetHome, SiteNode> groundStationSiteNodes = new Dictionary<RACommNetHome, SiteNode>();
 
         private readonly List<Vector3d> targetPoints = new List<Vector3d>();
         private readonly List<Vector3> targetPoints_out = new List<Vector3>();
@@ -53,17 +53,17 @@ namespace RealAntennas.MapUI
             RATelemetryUpdate.Install();
         }
         public void ConstructSiteNode(RACommNetHome home) {
-            if (groundStationSiteNodes.ContainsKey(home.name)) { 
+            if (groundStationSiteNodes.ContainsKey(home)) { 
                 return; 
             }
-            Debug.LogFormat($"[RACommNetUI] Adding GroundStationSiteNode for {home.name}");
+            Debug.LogFormat($"[RACommNetUI] Adding GroundStationSiteNode for {home.displaynodeName}");
             MapUI.GroundStationSiteNode gs = new MapUI.GroundStationSiteNode(home.Comm);
             SiteNode siteNode = SiteNode.Spawn(gs);
             Texture2D stationTexture = (GameDatabase.Instance.GetTexture(home.icon, false) is Texture2D tex) ? tex : GameDatabase.Instance.GetTexture(icon, false);
             // fetch default texture if conditional fails
             siteNode.wayPoint.node.SetIcon(Sprite.Create(stationTexture, new Rect(0, 0, stationTexture.width, stationTexture.height), new Vector2(0.5f, 0.5f), 100f));
             siteNode.wayPoint.node.OnUpdateVisible += home.OnUpdateVisible;
-            groundStationSiteNodes.Add(home.name, siteNode);
+            groundStationSiteNodes.Add(home, siteNode);
         }
 
         // If either one of these lists is nonempty, the links that are shown

--- a/src/RealAntennasProject/MapUI/RACommNetUI.cs
+++ b/src/RealAntennasProject/MapUI/RACommNetUI.cs
@@ -18,7 +18,7 @@ namespace RealAntennas.MapUI
         public Color color3dB = XKCDColors.BarbiePink;
         public Color color10dB = XKCDColors.Lavender;
 
-        public readonly Dictionary<RACommNetHome, SiteNode> groundStationSiteNodes = new Dictionary<RACommNetHome, SiteNode>();
+        public readonly Dictionary<string, SiteNode> groundStationSiteNodes = new Dictionary<string, SiteNode>();
 
         private readonly List<Vector3d> targetPoints = new List<Vector3d>();
         private readonly List<Vector3> targetPoints_out = new List<Vector3>();
@@ -53,17 +53,18 @@ namespace RealAntennas.MapUI
             RATelemetryUpdate.Install();
         }
         public void ConstructSiteNode(RACommNetHome home) {
-            if (groundStationSiteNodes.ContainsKey(home)) { 
-                return; 
+            if (groundStationSiteNodes.TryGetValue(home.nodeName, out SiteNode siteNode)) {
+            Debug.LogFormat($"[RACommNetUI] Destroying GroundStationSiteNode for {home.displaynodeName}");
+                Destroy(siteNode);
             }
             Debug.LogFormat($"[RACommNetUI] Adding GroundStationSiteNode for {home.displaynodeName}");
             MapUI.GroundStationSiteNode gs = new MapUI.GroundStationSiteNode(home.Comm);
-            SiteNode siteNode = SiteNode.Spawn(gs);
+            siteNode = SiteNode.Spawn(gs);
             Texture2D stationTexture = (GameDatabase.Instance.GetTexture(home.icon, false) is Texture2D tex) ? tex : GameDatabase.Instance.GetTexture(icon, false);
             // fetch default texture if conditional fails
             siteNode.wayPoint.node.SetIcon(Sprite.Create(stationTexture, new Rect(0, 0, stationTexture.width, stationTexture.height), new Vector2(0.5f, 0.5f), 100f));
             siteNode.wayPoint.node.OnUpdateVisible += home.OnUpdateVisible;
-            groundStationSiteNodes.Add(home, siteNode);
+            groundStationSiteNodes[home.nodeName] = siteNode;
         }
 
         // If either one of these lists is nonempty, the links that are shown

--- a/src/RealAntennasProject/MapUI/RACommNetUI.cs
+++ b/src/RealAntennasProject/MapUI/RACommNetUI.cs
@@ -53,18 +53,14 @@ namespace RealAntennas.MapUI
             RATelemetryUpdate.Install();
         }
         public void ConstructSiteNode(RACommNetHome home) {
-            if (groundStationSiteNodes.TryGetValue(home.nodeName, out SiteNode siteNode)) {
-            Debug.LogFormat($"[RACommNetUI] Destroying GroundStationSiteNode for {home.displaynodeName}");
-                Destroy(siteNode);
-            }
             Debug.LogFormat($"[RACommNetUI] Adding GroundStationSiteNode for {home.displaynodeName}");
             MapUI.GroundStationSiteNode gs = new MapUI.GroundStationSiteNode(home.Comm);
-            siteNode = SiteNode.Spawn(gs);
+            SiteNode siteNode = SiteNode.Spawn(gs);
             Texture2D stationTexture = (GameDatabase.Instance.GetTexture(home.icon, false) is Texture2D tex) ? tex : GameDatabase.Instance.GetTexture(icon, false);
             // fetch default texture if conditional fails
             siteNode.wayPoint.node.SetIcon(Sprite.Create(stationTexture, new Rect(0, 0, stationTexture.width, stationTexture.height), new Vector2(0.5f, 0.5f), 100f));
             siteNode.wayPoint.node.OnUpdateVisible += home.OnUpdateVisible;
-            groundStationSiteNodes[home.nodeName] = siteNode;
+            groundStationSiteNodes[home.nodeName] = siteNode; // skopos still needs these
         }
 
         // If either one of these lists is nonempty, the links that are shown


### PR DESCRIPTION
It turns out `name` isn't actually unique. We don't actually ever appear to call ConstructSiteNode on the same RACommNetHome, so let's just get rid of that check entirely. Skopos still wants the list/dictionary for its purposes, so that can stay.