### PR TITLE
Multiple performance enhancements of varying impact

### DIFF
--- a/src/RealAntennasProject/MapUI/RACommNetUI.cs
+++ b/src/RealAntennasProject/MapUI/RACommNetUI.cs
@@ -27,6 +27,20 @@ namespace RealAntennas.MapUI
         private readonly List<Vector3d> cone10Points = new List<Vector3d>();
         private readonly List<Vector3> cone10Points_out = new List<Vector3>();
         private readonly List<CommLink> commLinkList = new List<CommLink>();
+
+        // Reused scratch list to avoid ToList() allocation per node per frame.
+        private readonly List<CommLink> _scratchLinkList = new List<CommLink>();
+
+        // Reused gradient objects to avoid allocating new Gradient,
+        // GradientColorKey[], and GradientAlphaKey[] on every SetColorGradient call.
+        private readonly Gradient _cachedGradient = new Gradient();
+        private readonly GradientColorKey[] _colorKeys = new GradientColorKey[2];
+        private readonly GradientAlphaKey[] _alphaKeys = new GradientAlphaKey[2];
+
+        // Cached two-element array for SetPositions() on link line renderers,
+        // avoiding a heap allocation per link per frame.
+        private readonly Vector3[] _positionPair = new Vector3[2];
+
         private readonly Cone cone3 = new Cone();
         private readonly Cone cone10 = new Cone();
         private readonly Dictionary<CommLink, GameObject> linkRenderers = new Dictionary<CommLink, GameObject>();
@@ -52,9 +66,11 @@ namespace RealAntennas.MapUI
             }
             RATelemetryUpdate.Install();
         }
-        public void ConstructSiteNode(RACommNetHome home) {
-            if (groundStationSiteNodes.ContainsKey(home.name)) { 
-                return; 
+        public void ConstructSiteNode(RACommNetHome home)
+        {
+            if (groundStationSiteNodes.ContainsKey(home.name))
+            {
+                return;
             }
             Debug.LogFormat($"[RACommNetUI] Adding GroundStationSiteNode for {home.name}");
             MapUI.GroundStationSiteNode gs = new MapUI.GroundStationSiteNode(home.Comm);
@@ -97,15 +113,18 @@ namespace RealAntennas.MapUI
                 Vector3d scaledEnd = ScaledSpace.LocalToScaledSpace(link.end.precisePosition);
                 Camera cam = PlanetariumCamera.Camera;
                 Vector3 camPos = cam.transform.position;
-                float dStart = (float) Vector3d.Distance(camPos, scaledStart);
-                float dEnd = (float) Vector3d.Distance(camPos, scaledEnd);
+                float dStart = (float)Vector3d.Distance(camPos, scaledStart);
+                float dEnd = (float)Vector3d.Distance(camPos, scaledEnd);
                 renderer.startWidth = dStart * settings.lineScaleWidth / 1000;
                 renderer.endWidth = dEnd * settings.lineScaleWidth / 1000;
                 Color startColor = (settings.radioPerspective == RadioPerspective.Transmit) ? LinkColor(link.FwdMetric) : LinkColor(link.RevMetric);
                 Color endColor = (settings.radioPerspective == RadioPerspective.Transmit) ? LinkColor(link.RevMetric) : LinkColor(link.FwdMetric);
                 SetColorGradient(renderer, startColor, endColor);
                 renderer.positionCount = 2;
-                renderer.SetPositions(new Vector3[] { scaledStart, scaledEnd });
+                //Only call SetPositions once per link per frame, to avoid the overhead of multiple calls.
+                _positionPair[0] = scaledStart;
+                _positionPair[1] = scaledEnd;
+                renderer.SetPositions(_positionPair);
             }
         }
 
@@ -279,8 +298,18 @@ namespace RealAntennas.MapUI
         {
             //base.UpdateDisplay();
             if (CommNetNetwork.Instance == null) return;
-            DisableAllLinkRenderers();
-            DisableAllConeRenderers();
+
+            // Only blank renderers if the network produced valid results this frame.
+            // If the last rebuild was aborted (topology changing during scene load,
+            // vessel created/destroyed mid-frame), leave the previous frame's
+            // renderers visible rather than blanking the screen, which causes flicker.
+            bool rebuildValid = RACommNetScenario.RACN is RACommNetwork cn && cn.LastRebuildComplete;
+            if (rebuildValid)
+            {
+                DisableAllLinkRenderers();
+                DisableAllConeRenderers();
+            }
+
             if (CommNetUI.Mode == CommNetUI.DisplayMode.None) return;
             var settings = RACommNetScenario.MapUISettings;
             if (this.draw3dLines != MapView.Draw3DLines)
@@ -309,7 +338,9 @@ namespace RealAntennas.MapUI
                 {
                     foreach (RACommNode node in commNet.Nodes)
                     {
-                        GatherLinkLines(node.Values.ToList());
+                        _scratchLinkList.Clear();
+                        _scratchLinkList.AddRange(node.Values);
+                        GatherLinkLines(_scratchLinkList);
                         GatherAntennaCones(node);
                     }
                 }
@@ -328,13 +359,17 @@ namespace RealAntennas.MapUI
                             GatherAntennaCones(commNode);
                             break;
                         case CommNetUI.DisplayMode.VesselLinks:
-                            GatherLinkLines(commNode.Values.ToList());
+                            _scratchLinkList.Clear();
+                            _scratchLinkList.AddRange(commNode.Values);
+                            GatherLinkLines(_scratchLinkList);
                             GatherAntennaCones(commNode);
                             break;
                         case CommNetUI.DisplayMode.Path:
                             if (commPath.Count == 0)
                             {
-                                GatherLinkLines(commNode.Values.ToList());
+                                _scratchLinkList.Clear();
+                                _scratchLinkList.AddRange(commNode.Values);
+                                GatherLinkLines(_scratchLinkList);
                                 GatherAntennaCones(commNode);
                             }
                             foreach (CommLink link in commPath)
@@ -375,14 +410,16 @@ namespace RealAntennas.MapUI
             rend.enabled = false;
         }
 
-        public static void SetColorGradient(LineRenderer rend, Color startColor, Color endColor, float startAlpha=1, float endAlpha=1)
+        // Internal cached version used by all call sites within this class.
+        // Reuses _cachedGradient, _colorKeys, and _alphaKeys — no allocation per call.
+        private void SetColorGradient(LineRenderer rend, Color startColor, Color endColor, float startAlpha = 1, float endAlpha = 1)
         {
-            Gradient gradient = new Gradient();
-            gradient.SetKeys(
-                new GradientColorKey[] { new GradientColorKey(startColor, 0.0f), new GradientColorKey(endColor, 1.0f) },
-                new GradientAlphaKey[] { new GradientAlphaKey(startAlpha, 0.0f), new GradientAlphaKey(endAlpha, 1.0f) }
-            );
-            rend.colorGradient = gradient;
+            _colorKeys[0] = new GradientColorKey(startColor, 0.0f);
+            _colorKeys[1] = new GradientColorKey(endColor, 1.0f);
+            _alphaKeys[0] = new GradientAlphaKey(startAlpha, 0.0f);
+            _alphaKeys[1] = new GradientAlphaKey(endAlpha, 1.0f);
+            _cachedGradient.SetKeys(_colorKeys, _alphaKeys);
+            rend.colorGradient = _cachedGradient;
         }
 
         public override void SwitchMode(int step)

--- a/src/RealAntennasProject/Network/RACommNetNetwork.cs
+++ b/src/RealAntennasProject/Network/RACommNetNetwork.cs
@@ -10,7 +10,33 @@ namespace RealAntennas.Network
     public class RACommNetNetwork : CommNetNetwork
     {
         private const string ModTag = "[RACommNetNetwork]";
-        private bool requestInit = false;
+
+        // Set when the node topology has changed (vessels created/destroyed).
+        // Requires Validate() + full precompute.Initialize() before next rebuild.
+        private bool topologyDirty = false;
+
+        // Set when antennas on existing nodes have changed (e.g. parts staged,
+        // antennas deployed/retracted) but no nodes were added or removed.
+        // Requires only precompute.UpdateAllAntennas() — no re-pairing needed.
+        private bool antennaDirty = false;
+
+        // True while ResetNetwork() is firing OnNetworkInitialized and vessels
+        // are registering their CommNodes. InvalidateCache() is suppressed during
+        // this window — the single topologyDirty flag set at the end of
+        // ResetNetwork() covers the full Initialize() once all nodes are present.
+        private bool _initializing = false;
+
+        // Real-time timestamp of the last frame in which a full precompute was
+        // dispatched. Used by the time-warp throttle (Fix #1).
+        private float lastWallClockRebuild = 0f;
+
+        // In time warp, Planetarium.GetUniversalTime() advances so fast that the
+        // packedInterval/unpackedInterval check fires every frame, causing a full
+        // precompute pipeline dispatch on every frame regardless of warp rate.
+        // This floor caps compute dispatches to once per 200ms of real time,
+        // but only while time is warped — at 1x the guard is bypassed entirely
+        // so normal flight behaviour is completely unaffected.
+        private const float WarpRebuildInterval = 0.2f;
 
         protected override void Awake()
         {
@@ -34,11 +60,26 @@ namespace RealAntennas.Network
             //CommNetNetwork.Reset();       // Don't call this way, it will invoke the parent class' ResetNetwork()
         }
 
-        public void InvalidateCache() => requestInit = true;
-        private void VesselCreateHandler(Vessel v) => requestInit = true;
+        // Called from RACommNetVessel.DiscoverAntennas() when antenna list on an
+        // existing node changes. This does NOT add or remove CommNodes, so a full
+        // re-pair is not needed — only antenna data needs refreshing.
+        // Suppressed during ResetNetwork() since the single topologyDirty set at
+        // the end of that method covers everything once all nodes are registered.
+        public void InvalidateCache()
+        {
+            if (!_initializing)
+                antennaDirty = true;
+        }
+
+        // A new vessel has appeared: the node list has grown, so we need a full
+        // Validate() + Initialize() pass.
+        private void VesselCreateHandler(Vessel v) => topologyDirty = true;
+
         private void VesselDestroyHandler(Vessel v)
         {
-            requestInit = true;
+            // The node list is about to shrink. Mark topology dirty so we
+            // re-pair after the node is gone.
+            topologyDirty = true;
             if (v?.Connection?.Comm is RACommNode node)
             {
                 var l = new System.Collections.Generic.List<CommLink>();
@@ -64,15 +105,23 @@ namespace RealAntennas.Network
 
             CommNet = new RACommNetwork();
             Debug.Log($"{ModTag} Firing onNetworkInitialized()");
+            // Suppress InvalidateCache() during Fire() — vessels registering their
+            // CommNodes will call DiscoverAntennas() which calls InvalidateCache(),
+            // but we don't want N antennaDirty triggers here. Instead, set
+            // topologyDirty once after all vessels have registered so UpdateEarly()
+            // performs a single Validate() + Initialize() on the next frame when
+            // the node list is complete.
+            _initializing = true;
             GameEvents.CommNet.OnNetworkInitialized.Fire();
+            _initializing = false;
             Debug.Log($"{ModTag} Completed onNetworkInitialized()");
-            (CommNet as RACommNetwork).precompute.Initialize();
+            topologyDirty = true;
         }
 
         protected override void Update()
         {
             var RACN = commNet as RACommNetwork;
-            if (requestInit)
+            if (topologyDirty || antennaDirty)
                 RACN.Abort();
             else
                 RACN.CompleteRebuild();
@@ -82,22 +131,62 @@ namespace RealAntennas.Network
         {
             Profiler.BeginSample("RA UpdateEarly");
             var RACN = commNet as RACommNetwork;
-            if (requestInit)
+
+            if (topologyDirty)
             {
+                // Node list may have changed. Validate() checks FlightGlobals for
+                // any CommNodes that are missing from the network and adds them.
+                // Initialize() must always follow Validate() here so the pair table
+                // is built from the fully-corrected node list.
                 RACN.Validate();
                 RACN.precompute.Initialize();
-                requestInit = false;
+                topologyDirty = false;
+                antennaDirty = false;   // Initialize() already captured current antenna state
+            }
+            else if (antennaDirty)
+            {
+                // Node list is unchanged; only antenna properties (position, target
+                // direction, etc.) have been updated on existing nodes.
+                // UpdateAllAntennas() refreshes the precomputed antenna data in-place
+                // without rebuilding the O(N^2) pair table.
+                //
+                // However: Validate() is called here as a safety net. If a node was
+                // added between the last topology check and now (e.g. a vessel whose
+                // CommNode registered after VesselCreateHandler fired), Validate()
+                // will return true and we escalate to a full Initialize() so that
+                // vessel is not silently absent from the pair table.
+                bool unexpectedNodes = RACN.Validate();
+                if (unexpectedNodes)
+                {
+                    Debug.LogWarning($"{ModTag} Validate() found unexpected new nodes during antenna-only refresh. Escalating to full Initialize().");
+                    RACN.precompute.Initialize();
+                }
+                else
+                {
+                    RACN.precompute.UpdateAllAntennas();
+                }
+                antennaDirty = false;
             }
 
             double interval = System.Math.Min(packedInterval, unpackedInterval);
             // double tm = Time.timeSinceLevelLoad;
             double tm = Planetarium.GetUniversalTime();
             graphDirty |= tm > prevUpdate + interval;
-            bool compute = graphDirty || queueRebuild || commNet.IsDirty;
+
+            // At 1x time warp (normal flight/tracking station real-time),
+            // bypass the wall-clock guard so update cadence is unchanged.
+            // In time warp, enforce the real-time floor to prevent the game-time
+            // interval above from firing every frame.
+            float now = Time.realtimeSinceStartup;
+            bool wallClockReady = TimeWarp.CurrentRate <= 1f
+                                  || (now - lastWallClockRebuild >= WarpRebuildInterval);
+
+            bool compute = wallClockReady && (graphDirty || queueRebuild || commNet.IsDirty);
             RACN.StartRebuild(compute);
             if (compute)
             {
                 prevUpdate = tm;
+                lastWallClockRebuild = now;
                 graphDirty = queueRebuild = false;
             }
             Profiler.EndSample();

--- a/src/RealAntennasProject/Precompute/Precompute.cs
+++ b/src/RealAntennasProject/Precompute/Precompute.cs
@@ -59,7 +59,7 @@ namespace RealAntennas.Precompute
     {
         public readonly Dictionary<RealAntenna, int> allAntennas = new Dictionary<RealAntenna, int>();
         public readonly Dictionary<int, RealAntenna> allAntennasReverse = new Dictionary<int, RealAntenna>();
-        public NativeArray<AntennaData> antennaDataList;
+        public NativeList<AntennaData> antennaDataList = new NativeList<AntennaData>(Allocator.Persistent);
         public NativeList<int4> allAntennaPairs = new NativeList<int4>(Allocator.Persistent);
         public NativeList<int2> allNodePairs = new NativeList<int2>(Allocator.Persistent);
         public NativeHashMap<int2, int> bestMap;
@@ -121,16 +121,15 @@ namespace RealAntennas.Precompute
 
         public void Destroy()
         {
-            if (antennaDataList.IsCreated) antennaDataList.Dispose();
+            antennaDataList.Dispose();
             allAntennaPairs.Dispose();
             DisposeJobData();
         }
 
         public void Initialize(List<CommNet.CommNode> nodes = null)
         {
-            if (antennaDataList.IsCreated) antennaDataList.Dispose();
             nodes ??= RACommNetScenario.RACN.Nodes;
-            antennaDataList = GatherAllAntennas(allAntennas, allAntennasReverse, nodes);
+            GatherAllAntennas(allAntennas, allAntennasReverse, nodes, antennaDataList);
             PairAllAntennasAndNodes(allAntennaPairs, allNodePairs, allAntennas, nodes);
         }
 
@@ -714,11 +713,11 @@ namespace RealAntennas.Precompute
 
 
         // Iterate through all comm nodes, collect each RealAntenna, and extract a copy of data for precomputation
-        private NativeArray<AntennaData> GatherAllAntennas(Dictionary<RealAntenna, int> antennaDict, Dictionary<int, RealAntenna> reverseDict, List<CommNet.CommNode> nodes)
+        private void GatherAllAntennas(Dictionary<RealAntenna, int> antennaDict, Dictionary<int, RealAntenna> reverseDict, List<CommNet.CommNode> nodes, NativeList<AntennaData> antennaDatas)
         {
             antennaDict.Clear();
             reverseDict.Clear();
-            var antennaDatas = new NativeList<AntennaData>(Allocator.Persistent);
+            antennaDatas.Clear();
             int index = 0;
             if (nodes != null)
                 foreach (RACommNode node in nodes)
@@ -746,7 +745,6 @@ namespace RealAntennas.Precompute
                         });
                         index++;
                     }
-            return antennaDatas.AsArray();
         }
 
         internal void UpdateAllAntennas()

--- a/src/RealAntennasProject/RACommNetVessel.cs
+++ b/src/RealAntennasProject/RACommNetVessel.cs
@@ -14,6 +14,7 @@ namespace RealAntennas
         readonly List<RealAntenna> antennaList = new List<RealAntenna>();
         readonly List<RealAntenna> inactiveAntennas = new List<RealAntenna>();
         readonly List<CommNet.ModuleProbeControlPoint> probeControlPoints = new List<CommNet.ModuleProbeControlPoint>();
+        public IReadOnlyList<RealAntenna> InactiveAntennas => inactiveAntennas;
         private PartResourceDefinition electricChargeDef;
 
         [KSPField(isPersistant = true)] public bool powered = true;
@@ -71,6 +72,10 @@ namespace RealAntennas
                 (comm as RACommNode).RAAntennaList = DiscoverAntennas();
                 DiscoverProbeControlPoints();
                 vessel.connection = this;
+                // Initialise partCountCache to the current part count so that the
+                // first Update() frame does not immediately re-trigger DiscoverAntennas()
+                // due to the default value of 0 not matching the actual part count.
+                partCountCache = vessel.parts.Count;
                 networkInitialised = false;
                 if (CommNet.CommNetNetwork.Initialized)
                     OnNetworkInitialized();

--- a/src/RealAntennasProject/RACommNetwork.cs
+++ b/src/RealAntennasProject/RACommNetwork.cs
@@ -127,6 +127,12 @@ namespace RealAntennas
         }
         private bool calculating = false;
 
+        // True after a CompleteRebuild() that actually ran UpdateNetwork().
+        // False after an Abort(), or before any rebuild has completed.
+        // Used by the UI to decide whether to blank renderers this frame or
+        // leave the previous frame's results visible.
+        public bool LastRebuildComplete { get; private set; } = false;
+
         private bool IsPaused => (KSCPauseMenu.Instance && KSCPauseMenu.Instance.enabled) || (PauseMenu.exists && PauseMenu.isOpen);
         public virtual void StartRebuild(bool compute)
         {
@@ -166,6 +172,7 @@ namespace RealAntennas
                     OnNetworkPostUpdate();
                 tempWatch.Stop();
                 Profiler.EndSample();
+                LastRebuildComplete = true;
                 (RACommNetScenario.Instance as RACommNetScenario).metrics.AddMeasurement("Precompute LateRebuild", PrecomputeLateWatch.Elapsed.TotalMilliseconds);
                 (RACommNetScenario.Instance as RACommNetScenario).metrics.AddMeasurement("Full LateRebuild", tempWatch.Elapsed.TotalMilliseconds);
             }
@@ -176,6 +183,7 @@ namespace RealAntennas
         public virtual void Abort()
         {
             calculating = false;
+            LastRebuildComplete = false;
             precompute.Abort();
         }
 
@@ -235,17 +243,24 @@ namespace RealAntennas
             return sb.ToStringAndRelease();
         }
 
-        public void Validate()
+        // Returns true if any CommNodes were missing and had to be added.
+        // RACommNetNetwork.UpdateEarly() uses this return value to decide whether
+        // a topology-triggered Initialize() is still required after Validate()
+        // recovers nodes that were not yet present when topologyDirty was first set.
+        public bool Validate()
         {
+            bool addedNodes = false;
             foreach (Vessel v in FlightGlobals.Vessels)
             {
                 if (v.Connection?.Comm is RACommNode vcn && !nodes.Contains(vcn))
                 {
                     Debug.LogWarning($"{ModTag} Vessel {v} had commnode {vcn} not in the node list.");
                     Add(vcn);
+                    addedNodes = true;
                 }
             }
             CheckNodeConsistency();
+            return addedNodes;
         }
 
         public void CheckNodeConsistency()


### PR DESCRIPTION
Issue #1: UpdateDisplay() allocates garbage every frame. With many vessels this generates significant GC pressure, which can cause stuttering. >> Fix #1 - Replace node.Values.ToList() with a scratch list.
Issue #2:  NativeList memory leak in GatherAllAntennas. GatherAllAntennas in Initialize() constructs a NativeList with Allocator.Persistent then immediately calls AsArray(). AsArray() returns a view into the NativeList's backing memory, but the NativeList itself is not stored anywhere — it goes out of scope, meaning its Persistent allocation is never explicitly disposed. The returned array is backed by memory that is now orphaned from any lifecycle management. This is a native memory leak on every Initialize() call. >> Fix #2: Store the NativeList itself as the persistent field rather than extracting an array from it.
Issue #3: Network rebuild runs every frame — even on the map screen >> Fix #3 — Wall-clock throttle on UpdateEarly() - only really affects map view during warp.
Issue #4: PairAllAntennasAndNodes() is O(N²) in nodes × O(M²) in antennas and it's called on every Initialize() >>  Fix #4: Separate topologyDirty from antennaDirty.
Issue #5: SetColorGradient allocates a new Gradient() every frame per link. With N links × 60fps, this creates thousands of short-lived heap objects per second and is a direct cause of GC-induced frame hitching. >> Fix #5: Cache the gradient and key arrays as instance fields and reuse them.
Issue #6: Multiple redraws on scene load. >> Fix #6: LastRebuildComplete guard. Prevents the disable-then-blank cycle on frames where the network is mid-initialisation. Visible effect only - does not reduce actual CPU load.
Issue #7: DiscoverAntennas() fires N+1 times per vessel on scene load. >> Fix #7: Suppress N×DiscoverAntennas on load using _initializing flag.
Issue #8: Initialize() is called in ResetNetwork() before vessels have registered their nodes in ResetNetwork(). >> Fix #8: Suppress InvalidateCache() during the initial network setup window.
Issue #9: new Vector3[] allocated every frame per link in GatherLinkLines.  >> FIx #9: Cached Vector3[] field using _positionPair.