### PR TITLE
Refactor network cache invalidation and update logic

### DIFF
--- a/src/RealAntennasProject/Network/RACommNetNetwork.cs
+++ b/src/RealAntennasProject/Network/RACommNetNetwork.cs
@@ -10,7 +10,20 @@ namespace RealAntennas.Network
     public class RACommNetNetwork : CommNetNetwork
     {
         private const string ModTag = "[RACommNetNetwork]";
-        private bool requestInit = false;
+        // Set when the node topology has changed (vessels created/destroyed).
+        // Requires Validate() + full precompute.Initialize() before next rebuild.
+        private bool topologyDirty = false;
+
+        // Set when antennas on existing nodes have changed (e.g. parts staged,
+        // antennas deployed/retracted) but no nodes were added or removed.
+        // Requires only precompute.UpdateAllAntennas() — no re-pairing needed.
+        private bool antennaDirty = false;
+
+        // True while ResetNetwork() is firing OnNetworkInitialized and vessels
+        // are registering their CommNodes. InvalidateCache() is suppressed during
+        // this window — the single topologyDirty flag set at the end of
+        // ResetNetwork() covers the full Initialize() once all nodes are present.
+        private bool _initializing = false;
 
         protected override void Awake()
         {
@@ -34,11 +47,24 @@ namespace RealAntennas.Network
             //CommNetNetwork.Reset();       // Don't call this way, it will invoke the parent class' ResetNetwork()
         }
 
-        public void InvalidateCache() => requestInit = true;
-        private void VesselCreateHandler(Vessel v) => requestInit = true;
+        // Called from RACommNetVessel.DiscoverAntennas() when antenna list on an
+        // existing node changes. This does NOT add or remove CommNodes, so a full
+        // re-pair is not needed — only antenna data needs refreshing.
+        // Suppressed during ResetNetwork() since the single topologyDirty set at
+        // the end of that method covers everything once all nodes are registered.
+        public void InvalidateCache()
+        {
+            if (!_initializing)
+                antennaDirty = true;
+        }
+
+        private void VesselCreateHandler(Vessel v) => topologyDirty = true;
+
         private void VesselDestroyHandler(Vessel v)
         {
-            requestInit = true;
+            // The node list is about to shrink. Mark topology dirty so we
+            // re-pair after the node is gone.
+            topologyDirty = true;
             if (v?.Connection?.Comm is RACommNode node)
             {
                 var l = new System.Collections.Generic.List<CommLink>();
@@ -64,15 +90,23 @@ namespace RealAntennas.Network
 
             CommNet = new RACommNetwork();
             Debug.Log($"{ModTag} Firing onNetworkInitialized()");
+            // Suppress InvalidateCache() during Fire() — vessels registering their
+            // CommNodes will call DiscoverAntennas() which calls InvalidateCache(),
+            // but we don't want N antennaDirty triggers here. Instead, set
+            // topologyDirty once after all vessels have registered so UpdateEarly()
+            // performs a single Validate() + Initialize() on the next frame when
+            // the node list is complete.
+            _initializing = true;
             GameEvents.CommNet.OnNetworkInitialized.Fire();
+            _initializing = false;
             Debug.Log($"{ModTag} Completed onNetworkInitialized()");
-            (CommNet as RACommNetwork).precompute.Initialize();
+            topologyDirty = true;
         }
 
         protected override void Update()
         {
             var RACN = commNet as RACommNetwork;
-            if (requestInit)
+            if (topologyDirty || antennaDirty)
                 RACN.Abort();
             else
                 RACN.CompleteRebuild();
@@ -82,12 +116,42 @@ namespace RealAntennas.Network
         {
             Profiler.BeginSample("RA UpdateEarly");
             var RACN = commNet as RACommNetwork;
-            if (requestInit)
-            {
-                RACN.Validate();
-                RACN.precompute.Initialize();
-                requestInit = false;
-            }
+            if (topologyDirty || antennaDirty)
+                if (topologyDirty)
+                {
+                    // Node list may have changed. Validate() checks FlightGlobals for
+                    // any CommNodes that are missing from the network and adds them.
+                    // Initialize() must always follow Validate() here so the pair table
+                    // is built from the fully-corrected node list.
+                    RACN.Validate();
+                    RACN.precompute.Initialize();
+                    topologyDirty = false;
+                    antennaDirty = false;   // Initialize() already captured current antenna state
+                }
+                else if (antennaDirty)
+                {
+                    // Node list is unchanged; only antenna properties (position, target
+                    // direction, etc.) have been updated on existing nodes.
+                    // UpdateAllAntennas() refreshes the precomputed antenna data in-place
+                    // without rebuilding the O(N^2) pair table.
+                    //
+                    // However: Validate() is called here as a safety net. If a node was
+                    // added between the last topology check and now (e.g. a vessel whose
+                    // CommNode registered after VesselCreateHandler fired), Validate()
+                    // will return true and we escalate to a full Initialize() so that
+                    // vessel is not silently absent from the pair table.
+                    bool unexpectedNodes = RACN.Validate();
+                    if (unexpectedNodes)
+                    {
+                        Debug.LogWarning($"{ModTag} Validate() found unexpected new nodes during antenna-only refresh. Escalating to full Initialize().");
+                        RACN.precompute.Initialize();
+                    }
+                    else
+                    {
+                        RACN.precompute.UpdateAllAntennas();
+                    }
+                    antennaDirty = false;
+                }
 
             double interval = System.Math.Min(packedInterval, unpackedInterval);
             // double tm = Time.timeSinceLevelLoad;

--- a/src/RealAntennasProject/RACommNetwork.cs
+++ b/src/RealAntennasProject/RACommNetwork.cs
@@ -235,17 +235,24 @@ namespace RealAntennas
             return sb.ToStringAndRelease();
         }
 
-        public void Validate()
+        // Returns true if any CommNodes were missing and had to be added.
+        // RACommNetNetwork.UpdateEarly() uses this return value to decide whether
+        // a topology-triggered Initialize() is still required after Validate()
+        // recovers nodes that were not yet present when topologyDirty was first set.
+        public bool Validate()
         {
+            bool addedNodes = false;
             foreach (Vessel v in FlightGlobals.Vessels)
             {
                 if (v.Connection?.Comm is RACommNode vcn && !nodes.Contains(vcn))
                 {
                     Debug.LogWarning($"{ModTag} Vessel {v} had commnode {vcn} not in the node list.");
                     Add(vcn);
+                    addedNodes = true;
                 }
             }
             CheckNodeConsistency();
+            return addedNodes;
         }
 
         public void CheckNodeConsistency()


### PR DESCRIPTION
Separated topology and antenna changes with dedicated flags. Suppressed redundant invalidation during initialization. Optimized UpdateEarly() to minimize unnecessary network rebuilds. Validate() now returns a bool to trigger full Initialize() if new nodes are detected.