### PR TITLE
Change default target for antennas without a RACommNode to the main body (Kerbin/Earth)

### DIFF
--- a/src/RealAntennasProject/RealAntenna.cs
+++ b/src/RealAntennasProject/RealAntenna.cs
@@ -158,12 +158,7 @@ namespace RealAntennas
         
         public virtual void SetDefaultTarget()
         {
-            if (!(ParentNode is RACommNode raNode))
-            {
-                Debug.Log($"{ModTag} {ParentNode?.displayName} is not an RA comm node but has a RealAntenna! Defaulting target for {Name} to null");
-                Target = null;
-            }
-            else if (raNode.isGroundStation)
+            if (ParentNode is RACommNode raNode && raNode.isGroundStation)
                 Target = null;
             else
             {


### PR DESCRIPTION
Resolves #84, a bug introduced by #70 due to the erroneous assumption that there was no condition under which an antenna would spawn without a ParentNode.

Cursory testing suggests no other side effects, but also somehow that slipped through my testing, so who knows if there's a side effect I missed 😞. Antenna planning appears to work, ground station antennas appear to still be tracking, and newly spawned antennas have targeting again.