### PR TITLE
Improve behavior with switching RF bands in the antenna planner

### DIFF
--- a/src/RealAntennasProject/PlannerGUI.cs
+++ b/src/RealAntennasProject/PlannerGUI.cs
@@ -275,7 +275,7 @@ namespace RealAntennas
             {
                 var homes = RACommNetScenario.GroundStations.Values.Where(x => x.Comm is RACommNode);
                 foreach (RealAntenna ra in FilterAndSortAntennas(peer, homes)) 
-                    if (peer.Compatible(ra) && GUILayout.Button($"{ra.ParentNode.displayName} {ra.ToStringShort()}", buttonStyle))
+                    if (GUILayout.Button($"{ra.ParentNode.displayName} {ra.ToStringShort()}", buttonStyle))
                     {
                         antenna = ra;
                         res = true;

--- a/src/RealAntennasProject/PlannerGUI.cs
+++ b/src/RealAntennasProject/PlannerGUI.cs
@@ -156,6 +156,12 @@ namespace RealAntennas
             GUILayout.EndHorizontal();
             GUILayout.EndVertical();
 
+            if (!primaryAntenna.Compatible(fixedAntenna) && fixedAntenna.ParentNode is RACommNode raNode && raNode.RAAntennaList.FirstOrDefault(x => x.Compatible(primaryAntenna)) is RealAntenna ra)
+            {
+                fixedAntenna = ra;
+                RequestUpdate = true;
+            }
+
             var bodyList = new List<CelestialBody> { Planetarium.fetch.Sun };
             bodyList.AddRange(Planetarium.fetch.Home.orbitingBodies);
             bodyList.AddRange(Planetarium.fetch.Sun.orbitingBodies);

--- a/src/RealAntennasProject/PlannerGUI.cs
+++ b/src/RealAntennasProject/PlannerGUI.cs
@@ -158,6 +158,7 @@ namespace RealAntennas
 
             if (!primaryAntenna.Compatible(fixedAntenna) && fixedAntenna.ParentNode is RACommNode raNode && raNode.RAAntennaList.FirstOrDefault(x => x.Compatible(primaryAntenna)) is RealAntenna ra)
             {
+                ScreenMessages.PostScreenMessage($"{fixedAntenna.ParentNode.displayName} {fixedAntenna.Name} band changed from {fixedAntenna.RFBand.name} to {ra.RFBand.name} to match with {primaryAntenna.Name} band", 2, ScreenMessageStyle.UPPER_CENTER);
                 fixedAntenna = ra;
                 RequestUpdate = true;
             }

--- a/src/RealAntennasProject/Properties/AssemblyInfo.cs
+++ b/src/RealAntennasProject/Properties/AssemblyInfo.cs
@@ -43,3 +43,4 @@ using System.Runtime.InteropServices;
 
 [assembly: KSPAssemblyDependency("ClickThroughBlocker", 1, 8)]
 [assembly: KSPAssemblyDependency("KSPCommunityFixes", 1, 36, 0)]
+[assembly: KSPAssemblyDependency("KSPBurst", 1, 5, 5)]


### PR DESCRIPTION
> if primary antenna rf band changes and there exists an antenna at the fixed antenna node that matches that new rf band, switch to that antenna

Previously you could get situations like this, where there is no obvious mistake with the planner (besides a single non-bolded letter) yet it shows "No connection":
<img width="1356" height="756" alt="image" src="https://github.com/user-attachments/assets/384f235e-bba5-4762-899d-31d9bcd74edc" />


Video showing PR:
https://youtu.be/YPYZDZ4vzK8

Also remove a redundant check in RenderPanel