### PR TITLE
Calculate body noise for omni antennas

### DIFF
--- a/src/RealAntennasProject/Physics.cs
+++ b/src/RealAntennasProject/Physics.cs
@@ -14,6 +14,7 @@ namespace RealAntennas
         public const float MaxOmniGain = 5;
         public const float c = 2.998e8f;
         public const float CMB = 2.725f;
+        public const float SmallAngleThreshold = math.PI / 4; // maximum angle at which we use the small angle approximation for solid angles
         public static double SolarLuminosity => PhysicsGlobals.SolarLuminosity > double.Epsilon ? PhysicsGlobals.SolarLuminosity : Math.Pow(Planetarium.fetch.Home.orbit.semiMajorAxis, 2.0) * 4.0 * Math.PI * PhysicsGlobals.SolarLuminosityAtHome;
 
         //private static readonly double path_loss_constant = 20 * Math.Log10(4 * Math.PI / (2.998 * Math.Pow(10, 8)));
@@ -140,6 +141,17 @@ namespace RealAntennas
         //return body.isStar ? StarRadioTemp(baseTemp, rx.Frequency) : baseTemp;      // TODO: Get the BLACKBODY temperature!
 
 
+        public static float BodyNoiseTempOmni(double3 antPos, double3 bodyPos, float bodyRadius, float bodyTemp)
+        {
+            float bodyAngularRad = (float) math.radians(MathUtils.AngularRadius(bodyRadius, math.length(bodyPos - antPos)));
+            float totalAreaFrac = bodyAngularRad * bodyAngularRad / 4f;
+            if (bodyAngularRad > SmallAngleThreshold)
+            {
+                totalAreaFrac = (1f - math.cos(bodyAngularRad)) / 2f;
+            }
+            return bodyTemp * totalAreaFrac;
+        }
+
         public static float BodyNoiseTemp(double3 antPos,
                                             float gain,
                                             double3 dir,
@@ -148,7 +160,7 @@ namespace RealAntennas
                                             float bodyTemp,
                                             float beamwidth = -1)
         {
-            if (gain < MaxOmniGain) return 0;
+            if (gain < MaxOmniGain) return BodyNoiseTempOmni(antPos, bodyPos, bodyRadius, bodyTemp);
             if (bodyTemp < float.Epsilon) return 0;
             double3 toBody = bodyPos - antPos;
             float angle = (float) MathUtils.Angle2(toBody, dir);
@@ -313,20 +325,17 @@ namespace RealAntennas
         public static float AllBodyTemps(RealAntenna rx, Vector3d rxPointing)
         {
             float temp = 0;
-            if (rx.Shape != AntennaShape.Omni)
+            Profiler.BeginSample("RA Physics AllBodyTemps MainLoop");
+            RACommNode node = rx.ParentNode as RACommNode;
+            // Note there are ~33 bodies in RSS.
+            foreach (CelestialBody body in FlightGlobals.Bodies)
             {
-                Profiler.BeginSample("RA Physics AllBodyTemps MainLoop");
-                RACommNode node = rx.ParentNode as RACommNode;
-                // Note there are ~33 bodies in RSS.
-                foreach (CelestialBody body in FlightGlobals.Bodies)
+                if (!node.isGroundStation || !node.ParentBody.Equals(body))
                 {
-                    if (!node.isGroundStation || !node.ParentBody.Equals(body))
-                    {
-                        temp += BodyNoiseTemp(rx, body, rxPointing);
-                    }
+                    temp += BodyNoiseTemp(rx, body, rxPointing);
                 }
-                Profiler.EndSample();
             }
+            Profiler.EndSample();
             return temp;
         }
     }

--- a/src/RealAntennasProject/Physics.cs
+++ b/src/RealAntennasProject/Physics.cs
@@ -144,11 +144,7 @@ namespace RealAntennas
         public static float BodyNoiseTempOmni(double3 antPos, double3 bodyPos, float bodyRadius, float bodyTemp)
         {
             float bodyAngularRad = (float) math.radians(MathUtils.AngularRadius(bodyRadius, math.length(bodyPos - antPos)));
-            float totalAreaFrac = bodyAngularRad * bodyAngularRad / 4f;
-            if (bodyAngularRad > SmallAngleThreshold)
-            {
-                totalAreaFrac = (1f - math.cos(bodyAngularRad)) / 2f;
-            }
+            float totalAreaFrac = (bodyAngularRad > SmallAngleThreshold) ? (1f - math.cos(bodyAngularRad)) / 2f : bodyAngularRad * bodyAngularRad / 4f;
             return bodyTemp * totalAreaFrac;
         }
 

--- a/src/RealAntennasProject/Precompute/Precompute.cs
+++ b/src/RealAntennasProject/Precompute/Precompute.cs
@@ -660,7 +660,6 @@ namespace RealAntennas.Precompute
             NoiseFromOccluders(ant.position, ant.gain, ant.dir, ant.freq, ant.beamwidth, occluders);
         internal static float NoiseFromOccluders(double3 position, float gain, float3 dir, float freq, float beamwidth, in NativeArray<OccluderInfo> occluders)
         {
-            if (gain <= Physics.MaxOmniGain) return 0;
             float noise = 0;
             for (int i = 0; i < occluders.Length; i++)
             {


### PR DESCRIPTION
Resolves #77 by adding a separate function to calculate body noise for omni antennas. Adding this does not appear to cause any significant performance impact. (At least the total update time did not substantially change during my testing with an RP-1 save that happened to have many omni antennas.)

To handle the case where the antenna is very close to an occluder (like a ground station antenna, or an omni in low orbit), we define a threshold dependent on the angle where we change from the small angle approximation for the solid angle to the exact formula for the solid angle. By default this threshold is $\frac{\pi}{4}$ radians, or 45 degrees.

This PR may have balance implications. For RP-1 at least, the impact is minimal. Early omni antennas already have high receiver noise, so the extra ~100K of body noise has a net effect of <0.1dB in most cases. This primarily affects higher tech omni antennas. [Atmo-probe relays may be particularly affected by this?]