### PR TITLE
Update Coatl and Tantares part configs to match stock scale, add Knes and SSR MicroSat

### DIFF
--- a/GameData/RealAntennas/Parts/Coatl.cfg
+++ b/GameData/RealAntennas/Parts/Coatl.cfg
@@ -1,83 +1,140 @@
+// CA-A02 Conic Antenna
 @PART[antenna_cone_toggle]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
     %MODULE[ModuleRealAntenna] { %referenceGain = 3.0 }
 }
 
+// CA-A06 'Quetzal' Omni Antenna
 @PART[antenna_quetzal]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
     %MODULE[ModuleRealAntenna] { %referenceGain = 3.5 }
 }
 
+//CA-A07 Landvermesser Omni Antenna
 @PART[ca_landv_omni]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %referenceGain = 3.8 }
+    %MODULE[ModuleRealAntenna] { %referenceGain = 2.8 }
 }
 
+// CA-A10 Small Folding Relay Antenna
 @PART[dish_deploy_S]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter] {}
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.5 }
+}
+
+//CA-AD1-R Small Folding Relay Antenna
+@PART[dish_deploy_S2]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter] {}
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.625 }
+}
+
+//CA-MER-A400 Meridiani Dish Antenna
+@PART[mer_dish]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter] {}
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 3.25 }
+}
+
+// CA-A190 Hera Dish Antenna
+@PART[dish_hera]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter] {}
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 2.125 }
+}
+
+// CA-A180 Tatsujin Relay Antenna
+@PART[dish_tatsujin]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter] {}
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 1.375 }
+}
+
+// CA-A200 Quetzal Relay Antenna
+@PART[dish_quetzal]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter] {}
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 2.25 }
+}
+
+// CA-D02 Medium Folding Relay Antenna
+@PART[dish_xihe]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter] {}
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.95 }
+}
+
+//  CA-A20-B HGA Antenna, CA-AE20 HGA Antenna and Solar Panel
+@PART[ca_landv_orbiter_HGA|ca_landv_hga]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter] {}
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.55 }
+}
+
+// CA-A100 Small Dish Antenna
+@PART[dish_S]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter] {}
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.875 }
+}
+
+// CA-A300 Torekka Relay Antenna
+@PART[dish_L]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter] {}
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 2.75 }
+}
+
+// CAE-102 Vorona Dish Antenna
+@PART[ca_vor_dish]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter] {}
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 1.25 }
+}
+
+// CA-A01 Ground Plane Antenna
+@PART[antenna_tv]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter] {}
+    %MODULE[ModuleRealAntenna] { %referenceGain = 2.0 }
+}
+
+// CA-KPS KerbNet Position System Antenna
+@PART[ca_ant_gps]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter] {}
+    %MODULE[ModuleRealAntenna] { %referenceGain = 1.5 }
+}
+
+//CAE-A03 Vorona Communication Array
+@PART[ca_vor_comm]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter] {}
+    %MODULE[ModuleRealAntenna] { %referenceGain = 3.5 }
+}
+
+// CA-AMA Argo Mast Assembly, CA-AMA2 Argo Mast Assembly
+@PART[ca_argo-mk2-mast|ca_argo-mk4-mast]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter] {}
+    %MODULE[ModuleRealAntenna] { %referenceGain = 3.0 }
+}
+
+// CA-ED3 Argo Dish Antenna, CA-ED3B Argo Mk3 Dish Antenna
+@PART[ca_argo-mk2-hga|ca_argo-mk3-hga]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter] {}
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.75 }
+}
+
+// CA-RDA67 Argo Mk4 Dish Antenna
+@PART[ca_argo-mk4-hga]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
     %MODULE[ModuleRealAntenna] { %antennaDiameter = 1.0 }
 }
 
-@PART[dish_deploy_S2]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
-{
-    !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.8 }
-}
-
-@PART[mer_dish]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
-{
-    !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 4.0 }
-}
-
-@PART[dish_hera]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
-{
-    !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 2.5 }
-}
-
-@PART[dish_tatsujin]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
-{
-    !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 1.9 }
-}
-
-@PART[dish_quetzal]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
-{
-    !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 2.74 }
-}
-
-@PART[dish_xihe]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
-{
-    !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 2.5 }
-}
-
-@PART[ca_landv_orbiter_HGA]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
-{
-    !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.97 }
-}
-
-@PART[dish_S]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
-{
-    !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 1.55 }
-}
-
-@PART[dish_L]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
-{
-    !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 3.7 }
-}
-
-@PART[ca_vor_dish]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
-{
-    !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 1.55 }
-}

--- a/GameData/RealAntennas/Parts/Coatl.cfg
+++ b/GameData/RealAntennas/Parts/Coatl.cfg
@@ -23,77 +23,77 @@
 @PART[dish_deploy_S]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.5 }
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.55 }
 }
 
 //CA-AD1-R Small Folding Relay Antenna
 @PART[dish_deploy_S2]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.625 }
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.45 }
 }
 
 //CA-MER-A400 Meridiani Dish Antenna
 @PART[mer_dish]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 3.25 }
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 2.625 }
 }
 
 // CA-A190 Hera Dish Antenna
 @PART[dish_hera]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 2.125 }
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 1.5 }
 }
 
 // CA-A180 Tatsujin Relay Antenna
 @PART[dish_tatsujin]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 1.375 }
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 1.0 }
 }
 
 // CA-A200 Quetzal Relay Antenna
 @PART[dish_quetzal]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 2.25 }
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 1.9 }
 }
 
 // CA-D02 Medium Folding Relay Antenna
 @PART[dish_xihe]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.95 }
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.75 }
 }
 
 //  CA-A20-B HGA Antenna, CA-AE20 HGA Antenna and Solar Panel
 @PART[ca_landv_orbiter_HGA|ca_landv_hga]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.55 }
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.45 }
 }
 
 // CA-A100 Small Dish Antenna
 @PART[dish_S]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.875 }
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.625 }
 }
 
 // CA-A300 Torekka Relay Antenna
 @PART[dish_L]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 2.75 }
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 2.25 }
 }
 
 // CAE-102 Vorona Dish Antenna
 @PART[ca_vor_dish]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 1.25 }
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 1.125 }
 }
 
 // CA-A01 Ground Plane Antenna
@@ -128,13 +128,13 @@
 @PART[ca_argo-mk2-hga|ca_argo-mk3-hga]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.75 }
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.5 }
 }
 
 // CA-RDA67 Argo Mk4 Dish Antenna
 @PART[ca_argo-mk4-hga]:HAS[!MODULE[ModuleRealAntenna]]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 1.0 }
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.65 }
 }
 

--- a/GameData/RealAntennas/Parts/Knes.cfg
+++ b/GameData/RealAntennas/Parts/Knes.cfg
@@ -1,15 +1,15 @@
-// MRK-5b Antenna
-@PART[_Knes_Hermes_Antenna]:HAS[!MODULE[ModuleRealAntenna]]:NEEDS[Knes]:FOR[RealAntennas]
-{
-    !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.375 }
-}
-
 // MRK-5a Antenna
 @PART[_Knes_mrk_Antenna]:HAS[!MODULE[ModuleRealAntenna]]:NEEDS[Knes]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.5 }
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.425 }
+}
+
+// MRK-5b Antenna
+@PART[_Knes_Hermes_Antenna]:HAS[!MODULE[ModuleRealAntenna]]:NEEDS[Knes]:FOR[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter] {}
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.3 }
 }
 
 // C-2501 "Wall-e" Direct Antenna

--- a/GameData/RealAntennas/Parts/Knes.cfg
+++ b/GameData/RealAntennas/Parts/Knes.cfg
@@ -1,0 +1,27 @@
+// MRK-5b Antenna
+@PART[_Knes_Hermes_Antenna]:HAS[!MODULE[ModuleRealAntenna]]:NEEDS[Knes]:FOR[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter] {}
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.375 }
+}
+
+// MRK-5a Antenna
+@PART[_Knes_mrk_Antenna]:HAS[!MODULE[ModuleRealAntenna]]:NEEDS[Knes]:FOR[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter] {}
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.5 }
+}
+
+// C-2501 "Wall-e" Direct Antenna
+@PART[_Knes_DirectAntenna_bread]:HAS[!MODULE[ModuleRealAntenna]]:NEEDS[Knes]:FOR[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter] {}
+    %MODULE[ModuleRealAntenna] { %referenceGain = 3.0 }
+}
+
+// ATV "Leproux" Antenna
+@PART[_Knes_ATV_Antenna]:HAS[!MODULE[ModuleRealAntenna]]:NEEDS[Knes]:FOR[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter] {}
+    %MODULE[ModuleRealAntenna] { %referenceGain = 2.5 }
+}

--- a/GameData/RealAntennas/Parts/SquiggsySpaceResearch.cfg
+++ b/GameData/RealAntennas/Parts/SquiggsySpaceResearch.cfg
@@ -2,14 +2,14 @@
 @PART[FixedDish01]:HAS[!MODULE[ModuleRealAntenna]]:NEEDS[SquiggsySpaceResearch]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.75 }
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.625 }
 }
 
 // DTS-01 Antenna
 @PART[foldingDish01]:HAS[!MODULE[ModuleRealAntenna]]:NEEDS[SquiggsySpaceResearch]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.4 }
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.35 }
 }
 
 // Folded Dipole Antenna

--- a/GameData/RealAntennas/Parts/SquiggsySpaceResearch.cfg
+++ b/GameData/RealAntennas/Parts/SquiggsySpaceResearch.cfg
@@ -1,0 +1,20 @@
+// FD-01 Smallified Dish Antenna
+@PART[FixedDish01]:HAS[!MODULE[ModuleRealAntenna]]:NEEDS[SquiggsySpaceResearch]:FOR[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter] {}
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.75 }
+}
+
+// DTS-01 Antenna
+@PART[foldingDish01]:HAS[!MODULE[ModuleRealAntenna]]:NEEDS[SquiggsySpaceResearch]:FOR[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter] {}
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.4 }
+}
+
+// Folded Dipole Antenna
+@PART[foldedDipole]:HAS[!MODULE[ModuleRealAntenna]]:NEEDS[SquiggsySpaceResearch]:FOR[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter] {}
+    %MODULE[ModuleRealAntenna] { %referenceGain = 0.75 }
+}

--- a/GameData/RealAntennas/Parts/Tantares.cfg
+++ b/GameData/RealAntennas/Parts/Tantares.cfg
@@ -9,7 +9,7 @@
 @PART[atria_high_gain_antenna_srf_1|atria_high_gain_antenna_srf_2|atria_high_gain_antenna_srf_3]:NEEDS[Tantares]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-	%MODULE[ModuleRealAntenna]{	%antennaDiameter = 0.8}
+	%MODULE[ModuleRealAntenna]{	%antennaDiameter = 0.375}
 }
 
 // Atria Low Gain Antenna (Fixed)||Atria Low Gain Antenna (Folding)||Atria Low Gain Antenna (Extending)
@@ -37,7 +37,7 @@
 @PART[vela_high_gain_antenna_srf_1]:NEEDS[Tantares]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 1.0 }
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.6 }
 }
 
 // Eridani Low Gain Antenna A||Eridani Low Gain Antenna B
@@ -51,21 +51,21 @@
 @PART[eridani_high_gain_antenna_srf_1]:NEEDS[Tantares]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.8 }
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.65 }
 }
 
 // Atria-Octans Basic High Gain Antenna
 @PART[octans_basic_high_gain_antenna_srf_2]:NEEDS[Tantares]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.5 }
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.375 }
 }
 
 // Octans High Gain Antenna A||Octans High Gain Antenna B
 @PART[octans_high_gain_antenna_srf_1|octans_high_gain_antenna_srf_2]:NEEDS[Tantares]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 1.5 }
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.375 }
 }
 
 // Octans Whip Antenna A||Octans Whip Antenna B
@@ -80,4 +80,11 @@
 {
     !MODULE[ModuleDataTransmitter] {}
     %MODULE[ModuleRealAntenna] { %referenceGain = 0.8 }
+}
+
+// Libra High Gain Antenna
+@PART[lk_v2_high_gain_antenna_srf_2]:NEEDS[Tantares]:FOR[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter] {}
+    %MODULE[ModuleRealAntenna] { %referenceGain = 0.425 }
 }

--- a/GameData/RealAntennas/Parts/Tantares.cfg
+++ b/GameData/RealAntennas/Parts/Tantares.cfg
@@ -9,24 +9,24 @@
 @PART[atria_high_gain_antenna_srf_1|atria_high_gain_antenna_srf_2|atria_high_gain_antenna_srf_3]:NEEDS[Tantares]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-	%MODULE[ModuleRealAntenna]{	%antennaDiameter = 0.375}
+	%MODULE[ModuleRealAntenna]{	%antennaDiameter = 0.325}
 }
 
 // Atria Low Gain Antenna (Fixed)||Atria Low Gain Antenna (Folding)||Atria Low Gain Antenna (Extending)
 @PART[atria_low_gain_antenna_srf_1|atria_low_gain_antenna_srf_2|atria_low_gain_antenna_srf_3]:NEEDS[Tantares]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %referenceGain = 1.0 }
+    %MODULE[ModuleRealAntenna] { %referenceGain = 1.5 }
 }
 
-// Lepus High Gain Antenna (Fixed)||Lepus High Gain Antenna (Folding)
+// Lepus High Gain Antenna (Fixed)||Lepus High Gain Antenna (Folding) // Deprecated
 @PART[lepus_high_gain_antenna_srf_1|lepus_high_gain_antenna_srf_2]:NEEDS[Tantares]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 1.0 }
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.425 }
 }
 
-// Lepus Low Gain Antenna (Fixed)||Lepus Low Gain Antenna (Folding)
+// Lepus Low Gain Antenna (Fixed)||Lepus Low Gain Antenna (Folding) // Deprecated
 @PART[lepus_low_gain_antenna_srf_1|lepus_low_gain_antenna_srf_2]:NEEDS[Tantares]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
@@ -58,33 +58,47 @@
 @PART[octans_basic_high_gain_antenna_srf_2]:NEEDS[Tantares]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.375 }
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.325 }
 }
 
 // Octans High Gain Antenna A||Octans High Gain Antenna B
 @PART[octans_high_gain_antenna_srf_1|octans_high_gain_antenna_srf_2]:NEEDS[Tantares]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.375 }
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.3 }
 }
 
-// Octans Whip Antenna A||Octans Whip Antenna B
-@PART[octans_whip_antenna_srf_1|octans_whip_antenna_srf_2]:NEEDS[Tantares]:FOR[RealAntennas]
+// Octans Whip Antenna A
+@PART[octans_whip_antenna_srf_1]:NEEDS[Tantares]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %referenceGain = 0.5 }
+    %MODULE[ModuleRealAntenna] { %referenceGain = 1.5 }
+}
+
+// Octans Whip Antenna B
+@PART[octans_whip_antenna_srf_2]:NEEDS[Tantares]:FOR[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter] {}
+    %MODULE[ModuleRealAntenna] { %referenceGain = 3.0 }
 }
 
 // Andromeda Low Gain Antenna
 @PART[andromeda_low_gain_antenna_srf_1]:NEEDS[Tantares]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %referenceGain = 0.8 }
+    %MODULE[ModuleRealAntenna] { %referenceGain = 1.5 }
 }
 
 // Libra High Gain Antenna
 @PART[lk_v2_high_gain_antenna_srf_2]:NEEDS[Tantares]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %referenceGain = 0.425 }
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.425 }
+}
+
+// Libra Low Gain Antenna
+@PART[lk_v2_high_gain_antenna_srf_2]:NEEDS[Tantares]:FOR[RealAntennas]
+{
+    !MODULE[ModuleDataTransmitter] {}
+    %MODULE[ModuleRealAntenna] { %referenceGain = 2.0 }
 }

--- a/GameData/RealAntennas/Parts/TantaresSP.cfg
+++ b/GameData/RealAntennas/Parts/TantaresSP.cfg
@@ -37,7 +37,7 @@
 @PART[ye8_high_gain_antenna_srf_2]:NEEDS[TantaresSP]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.3 }
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.15 }
 }
 
 // Emerald Low Gain Antenna A||Emerald Low Gain Antenna B||Emerald Low Gain Antenna C

--- a/GameData/RealAntennas/Parts/TantaresSP.cfg
+++ b/GameData/RealAntennas/Parts/TantaresSP.cfg
@@ -2,21 +2,21 @@
 @PART[1mv_high_gain_antenna_srf_1]:NEEDS[TantaresSP]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 2.0 }
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 1.25 }
 }
 
 // Beryl High Gain Antenna
 @PART[3mv_high_gain_antenna_srf_1]:NEEDS[TantaresSP]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 2.5 }
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 1.7 }
 }
 
 // Amethyst High Gain Antenna
 @PART[4mv_v_high_gain_antenna_srf_1]:NEEDS[TantaresSP]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 1.8 }
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.9 }
 }
 
 // Quartz Low Gain Antenna
@@ -37,19 +37,19 @@
 @PART[ye8_high_gain_antenna_srf_2]:NEEDS[TantaresSP]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %referenceGain = 1.85 }
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.3 }
 }
 
 // Emerald Low Gain Antenna A||Emerald Low Gain Antenna B||Emerald Low Gain Antenna C
 @PART[ye8_low_gain_antenna_srf_1|ye8_low_gain_antenna_srf_2|ye8_low_gain_antenna_srf_3]:NEEDS[TantaresSP]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %referenceGain = 1.0 }
+    %MODULE[ModuleRealAntenna] { %referenceGain = 1.5 }
 }
 
 // Pearl Size 0 High Gain Antenna
 @PART[1f_high_gain_antenna_s0_1]:NEEDS[TantaresSP]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 1.25 }
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.625 }
 }

--- a/GameData/RealAntennas/Parts/TantaresSP.cfg
+++ b/GameData/RealAntennas/Parts/TantaresSP.cfg
@@ -2,14 +2,14 @@
 @PART[1mv_high_gain_antenna_srf_1]:NEEDS[TantaresSP]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 1.25 }
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 1.33 }
 }
 
 // Beryl High Gain Antenna
 @PART[3mv_high_gain_antenna_srf_1]:NEEDS[TantaresSP]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 1.7 }
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 1.66 }
 }
 
 // Amethyst High Gain Antenna
@@ -37,7 +37,7 @@
 @PART[ye8_high_gain_antenna_srf_2]:NEEDS[TantaresSP]:FOR[RealAntennas]
 {
     !MODULE[ModuleDataTransmitter] {}
-    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.15 }
+    %MODULE[ModuleRealAntenna] { %antennaDiameter = 0.2 }
 }
 
 // Emerald Low Gain Antenna A||Emerald Low Gain Antenna B||Emerald Low Gain Antenna C


### PR DESCRIPTION
- Corrects antennaDiameter for all Coatl Aerospace and Tantares/TantaresSP dishes to match model diameters in-game at stock scale
- Adjusts some referenceGain values for omnis to make more sense compared to stock parts.
- Changes TantaresSP Emerald HGA from omni to directional. It seems small helical antennas are classed as omni, but this is a decent half-meter length helix-type antenna with tracking mode that was clearly intended as a directional high-gain, so 0.2m directional made more sense to me than its current measly 1.85 dBi omni setting. I'm not an antenna expert so the value was roughly based off of Googling but results in a starting L-band gain of 7.6 dBi.
- Adds parts configs for Knes and SSR MicroSat Revived (SquigglySpaceResearch)