### PR TITLE
In-flight planner improvements

### DIFF
--- a/src/RealAntennasProject/PlannerGUI.cs
+++ b/src/RealAntennasProject/PlannerGUI.cs
@@ -263,7 +263,7 @@ namespace RealAntennas
                                 res = true;
                             }
                 }
-                foreach (Vessel v in FlightGlobals.Vessels.Where(x => x.Connection is RACommNetVessel))
+                foreach (Vessel v in FlightGlobals.Vessels.Where(x => x.Connection is RACommNetVessel).OrderBy(x => x != FlightGlobals.ActiveVessel))
                 {
                     RACommNetVessel rcv = v.Connection as RACommNetVessel;
                     foreach (RealAntenna ra in rcv.antennaList)

--- a/src/RealAntennasProject/PlannerGUI.cs
+++ b/src/RealAntennasProject/PlannerGUI.cs
@@ -263,13 +263,22 @@ namespace RealAntennas
                                 res = true;
                             }
                 }
-                foreach (Vessel v in FlightGlobals.Vessels.Where(x => x.Connection?.Comm is RACommNode))
-                    foreach (RealAntenna ra in (v.Connection.Comm as RACommNode).RAAntennaList)
+                foreach (Vessel v in FlightGlobals.Vessels.Where(x => x.Connection is RACommNetVessel))
+                {
+                    RACommNetVessel rcv = v.Connection as RACommNetVessel;
+                    foreach (RealAntenna ra in rcv.antennaList)
                         if (GUILayout.Button($"{v.GetDisplayName()} {ra.ToStringShort()}", buttonStyle))
                         {
                             antenna = ra;
                             res = true;
                         }
+                    foreach (RealAntenna ra in rcv.inactiveAntennas)
+                        if (GUILayout.Button($"{v.GetDisplayName()} {ra.ToStringShort()} (undeployed)", buttonStyle))
+                        {
+                            antenna = ra;
+                            res = true;
+                        }
+                }
             }
             else
             {

--- a/src/RealAntennasProject/RACommNetVessel.cs
+++ b/src/RealAntennasProject/RACommNetVessel.cs
@@ -11,8 +11,8 @@ namespace RealAntennas
     public class RACommNetVessel : CommNet.CommNetVessel
     {
         protected const string ModTag = "[RealAntennasCommNetVessel]";
-        readonly List<RealAntenna> antennaList = new List<RealAntenna>();
-        readonly List<RealAntenna> inactiveAntennas = new List<RealAntenna>();
+        public readonly List<RealAntenna> antennaList = new List<RealAntenna>();
+        public readonly List<RealAntenna> inactiveAntennas = new List<RealAntenna>();
         readonly List<CommNet.ModuleProbeControlPoint> probeControlPoints = new List<CommNet.ModuleProbeControlPoint>();
         private PartResourceDefinition electricChargeDef;
 


### PR DESCRIPTION
Show undeployed antennas in planner, and make the active vessel first in the list (to match what it looks like in the editor)

<img width="1713" height="607" alt="image" src="https://github.com/user-attachments/assets/8278bf93-6e4f-4177-9a59-aa4c5e044cd2" />
<img width="1625" height="606" alt="image" src="https://github.com/user-attachments/assets/22d7d69f-f09a-45a0-9a69-ae2fc439a81b" /> (scrolled over to see the full text)
