### PR TITLE
Antenna Duty, Multi-Band Transceivers, and Planner Updates

### DIFF
--- a/src/RealAntennasProject/AntennaDuty.cs
+++ b/src/RealAntennasProject/AntennaDuty.cs
@@ -1,0 +1,38 @@
+﻿using System;
+
+namespace RealAntennas
+{
+    // What kind of traffic an antenna/link is permitted to carry.
+    // Telemetry for command & Control and Science for Science data
+    [Flags]
+    public enum AntennaDuty
+    {
+        Telemetry = 1 << 0,
+        Science = 1 << 1,
+        Both = Telemetry | Science
+    }
+
+    public static class AntennaDutyExtensions
+    {
+        public const string DefaultModeName = "Both";
+        public static readonly string[] ModeNames = { "Telemetry", "Science", DefaultModeName };
+        public static readonly string[] ModeDisplayNames = { "Telemetry Only", "Science Only", "Telemetry + Science" };
+
+        public static AntennaDuty FromModeName(string name) => name switch
+        {
+            "Telemetry" => AntennaDuty.Telemetry,
+            "Science" => AntennaDuty.Science,
+            _ => AntennaDuty.Both,
+        };
+
+        public static string ToModeName(this AntennaDuty duty) => duty switch
+        {
+            AntennaDuty.Telemetry => "Telemetry",
+            AntennaDuty.Science => "Science",
+            _ => "Both",
+        };
+
+        public static bool CanHandleTelemetry(this AntennaDuty duty) => (duty & AntennaDuty.Telemetry) != 0;
+        public static bool CanHandleScience(this AntennaDuty duty) => (duty & AntennaDuty.Science) != 0;
+    }
+}

--- a/src/RealAntennasProject/AntennaRFDirection.cs
+++ b/src/RealAntennasProject/AntennaRFDirection.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+namespace RealAntennas
+{
+    
+    // The physical RF direction(s) a transceiver is capable of. Named in
+    // hardware terms (Transmit/Receive) since "uplink"/"downlink" depends on reference
+    [Flags]
+    public enum AntennaRFDirection
+    {
+        Transmit = 1 << 0,
+        Receive = 1 << 1,
+        Bidirectional = Transmit | Receive
+    }
+
+    public static class AntennaRFDirectionExtensions
+    {
+        public const string DefaultModeName = "Bidirectional";
+        // Order matters: this is also the UI_ChooseOption cycle order in the VAB.
+        public static readonly string[] ModeNames = { "Uplink", "Downlink", DefaultModeName };
+        public static readonly string[] ModeDisplayNames = { "Uplink Only (Receive)", "Downlink Only (Transmit)", "Bidirectional" };
+
+        public static AntennaRFDirection FromModeName(string name) => name switch
+        {
+            "Uplink" => AntennaRFDirection.Receive,
+            "Downlink" => AntennaRFDirection.Transmit,
+            _ => AntennaRFDirection.Bidirectional,
+        };
+
+        public static bool CanTransmitRF(this AntennaRFDirection dir) => (dir & AntennaRFDirection.Transmit) != 0;
+        public static bool CanReceiveRF(this AntennaRFDirection dir) => (dir & AntennaRFDirection.Receive) != 0;
+    }
+}

--- a/src/RealAntennasProject/Kerbalism/Kerbalism.cs
+++ b/src/RealAntennasProject/Kerbalism/Kerbalism.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 
@@ -25,7 +25,12 @@ namespace RealAntennas.Kerbalism
                     CommNet.CommPath path = new CommNet.CommPath();
                     (node.Net as RACommNetwork).FindHome(node, path);
                     status = !raCNV.IsConnectedHome ? 2 : path.Count == 1 ? 0 : 1;
-                    rate = (node.Net as RACommNetwork).MaxDataRateToHome(node) / 8e6;    // Convert rate from bps to MBps;
+                    // FKerbalism does its own science-file transmission
+                    // sim off this single 'rate' field rather than going through
+                    // ModuleRealAntenna.TransmitData/CanTransmit, so the duty gate
+                    // has to be applied here instead - report 0 if any hop on the
+                    // current best path is Telemetry-only.
+                    rate = (node.Net as RACommNetwork).MaxScienceDataRateToHome(node) / 8e6;    // Convert rate from bps to MBps;
                     if (transmitting) ec += ra.PowerDrawLinear * packetInterval * 1e-6;    // 1 EC/sec = 1KW.  Draw(mw) * interval(sec) * mW -> kW conversion
                     if (node[path.First.end] is RACommLink link)
                     {

--- a/src/RealAntennasProject/MapUI/RACommNetUI.cs
+++ b/src/RealAntennasProject/MapUI/RACommNetUI.cs
@@ -1,4 +1,4 @@
-﻿using CommNet;
+using CommNet;
 using RealAntennas.Network;
 using System;
 using System.Collections.Generic;
@@ -84,8 +84,11 @@ namespace RealAntennas.MapUI
                 {
                     go = new GameObject("LinkLineRenderer");
                     LineRenderer rend = go.AddComponent<LineRenderer>();
-                    bool dotted = link.FwdAntennaTx.TechLevelInfo.Level < RACommNetScenario.minRelayTL ||
-                                  link.FwdAntennaRx.TechLevelInfo.Level < RACommNetScenario.minRelayTL;
+                    // Fwd/Rev antennas can each independently be null now
+                    bool dotted = link.FwdAntennaTx?.TechLevelInfo.Level < RACommNetScenario.minRelayTL ||
+                                  link.FwdAntennaRx?.TechLevelInfo.Level < RACommNetScenario.minRelayTL ||
+                                  link.RevAntennaTx?.TechLevelInfo.Level < RACommNetScenario.minRelayTL ||
+                                  link.RevAntennaRx?.TechLevelInfo.Level < RACommNetScenario.minRelayTL;
                     InitializeRenderer(rend, dotted);
                     linkRenderers.Add(link, go);
                 }

--- a/src/RealAntennasProject/ModuleRealAntenna.cs
+++ b/src/RealAntennasProject/ModuleRealAntenna.cs
@@ -1,4 +1,4 @@
-﻿using KSPCommunityFixes;
+using KSPCommunityFixes;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -56,6 +56,36 @@ namespace RealAntennas
 
         public Antenna.BandInfo RFBandInfo => Antenna.BandInfo.All[RFBand];
 
+        [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "Antenna Duty", groupName = PAWGroup),
+         UI_ChooseOption(scene = UI_Scene.Editor)]
+        public string AntennaDutyMode = AntennaDutyExtensions.DefaultModeName;
+
+        [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "Link Direction", groupName = PAWGroup),
+         UI_ChooseOption(scene = UI_Scene.Editor)]
+        public string LinkRoleMode = AntennaRFDirectionExtensions.DefaultModeName;
+
+        [KSPField(isPersistant = true, guiActiveEditor = true, guiName = "Dual-Band Transceiver", groupName = PAWGroup),
+         UI_Toggle(disabledText = "Single Transceiver", enabledText = "Dual Transceiver", scene = UI_Scene.Editor)]
+        public bool MultiTransceiver = false;
+
+        // The secondary transceiver shares this part's physical dish with the
+        // primary, but can run a different band and be locked transmit- or
+        // receive-only - e.g. an X-band downlink alongside an S-band uplink.
+        [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "Secondary RF Band", groupName = PAWGroup),
+         UI_ChooseOption(scene = UI_Scene.Editor)]
+        public string SecondaryRFBand = "S";
+
+        [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "Secondary Link Direction", groupName = PAWGroup),
+         UI_ChooseOption(scene = UI_Scene.Editor)]
+        public string SecondaryLinkRoleMode = AntennaRFDirectionExtensions.DefaultModeName;
+
+        [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "Secondary Antenna Duty", groupName = PAWGroup),
+         UI_ChooseOption(scene = UI_Scene.Editor)]
+        public string SecondaryAntennaDutyMode = AntennaDutyExtensions.DefaultModeName;
+
+        [KSPField] public float multiTransceiverCostMult = 1.4f;
+        [KSPField] public float multiTransceiverMassMult = 1.25f;
+
         [KSPField(guiActive = true, guiActiveEditor = true, guiName = "Power (Active)", groupName = PAWGroup)]
         public string sActivePowerConsumed = string.Empty;
 
@@ -74,6 +104,7 @@ namespace RealAntennas
         protected const string ModTag = "[ModuleRealAntenna] ";
         public static readonly string ModuleName = "ModuleRealAntenna";
         public RealAntenna RAAntenna;
+        public RealAntenna RASecondaryAntenna;
         public PlannerGUI plannerGUI;
 
         private ModuleDeployableAntenna deployableAntenna;
@@ -90,6 +121,9 @@ namespace RealAntennas
 
         public float PowerDraw => RATools.LogScale(PowerDrawLinear);
         public float PowerDrawLinear => RATools.LinearScale(TxPower) / RAAntenna.PowerEfficiency;
+        // idle draw for both transceivers combined, since a
+        // dual-band part physically runs two receiver chains at once.
+        public float TotalIdlePowerDraw => RAAntenna.IdlePowerDraw + (MultiTransceiver && RASecondaryAntenna != null ? RASecondaryAntenna.IdlePowerDraw : 0f);
 
         [KSPEvent(active = true, guiActive = true, guiName = "Antenna Targeting", groupName = PAWGroup)]
         void AntennaTargetGUI() => Targeting.AntennaTargetManager.AcquireGUI(RAAntenna);
@@ -115,6 +149,10 @@ namespace RealAntennas
         {
             base.OnAwake();
             RAAntenna = new RealAntennaDigital(part.partInfo?.title ?? part.name);
+            // Always constructed so the rest of the code never needs a null check;
+            // it just isn't added to the vessel's antenna list unless MultiTransceiver
+            // is enabled (see RACommNetVessel.DiscoverAntennas).
+            RASecondaryAntenna = new RealAntennaDigital($"{part.partInfo?.title ?? part.name} (Secondary)");
         }
 
         public override void OnLoad(ConfigNode node)
@@ -141,8 +179,15 @@ namespace RealAntennas
         {
             RAAntenna.Name = part.partInfo?.title ?? part.name;
             RAAntenna.Parent = this;
+            // Secondary's Parent/Name must be wired up BEFORE the primary loads its
+            // config: LoadFromConfigNode may set RAAntenna.Target, whose setter
+            // mirrors onto RASecondaryAntenna - that only works if RASecondaryAntenna
+            // is already reachable as parentModule.RASecondaryAntenna at that point.
+            RASecondaryAntenna.Name = $"{part.partInfo?.title ?? part.name} (Secondary)";
+            RASecondaryAntenna.Parent = this;
             RAAntenna.LoadFromConfigNode(node);
             Gain = RAAntenna.Gain;
+            RASecondaryAntenna.LoadSecondaryFromConfigNode(node);
         }
 
         public override void OnStart(StartState state)
@@ -186,6 +231,8 @@ namespace RealAntennas
             ApplyGameSettings();
             SetupUICallbacks();
             ConfigBandOptions();
+            ConfigDutyOptions();
+            ConfigLinkRoleOptions();
             SetupIdlePower();
             RecalculateFields();
             SetFieldVisibility();
@@ -208,7 +255,7 @@ namespace RealAntennas
             if (HighLogic.LoadedSceneIsFlight && Condition != AntennaCondition.Disabled)
             {
                 var electricCharge = resHandler.inputResources.First(x => x.id == PartResourceLibrary.ElectricityHashcode);
-                electricCharge.rate = Condition != AntennaCondition.PermanentShutdown && (Kerbalism.Kerbalism.KerbalismAssembly is null) ? RAAntenna.IdlePowerDraw : 0;
+                electricCharge.rate = Condition != AntennaCondition.PermanentShutdown && (Kerbalism.Kerbalism.KerbalismAssembly is null) ? TotalIdlePowerDraw : 0;
                 string err = "";
                 resHandler.UpdateModuleResourceInputs(ref err, 1, 1, false, false);
             }
@@ -233,13 +280,29 @@ namespace RealAntennas
             RAAntenna.TechLevelInfo = TechLevelInfo.GetTechLevel(techLevel);
             RAAntenna.TxPower = TxPower;
             RAAntenna.RFBand = Antenna.BandInfo.All[RFBand];
+            RAAntenna.Duty = AntennaDutyExtensions.FromModeName(AntennaDutyMode);
+            RAAntenna.RFDirection = AntennaRFDirectionExtensions.FromModeName(LinkRoleMode);
             RAAntenna.SymbolRate = RAAntenna.RFBand.MaxSymbolRate(techLevel);
             RAAntenna.Gain = Gain = (antennaDiameter > 0) ? Physics.GainFromDishDiamater(antennaDiameter, RFBandInfo.Frequency, RAAntenna.AntennaEfficiency) : Physics.GainFromReference(referenceGain, referenceFrequency * 1e6f, RFBandInfo.Frequency);
-            double idleDraw = RAAntenna.IdlePowerDraw * 1000;
-            sIdlePowerConsumed = $"{idleDraw:F2} Watts";
-            sActivePowerConsumed = $"{idleDraw + (PowerDrawLinear / 1000):F2} Watts";
             int ModulationBits = (RAAntenna as RealAntennaDigital).modulator.ModulationBitsFromTechLevel(TechLevel);
             (RAAntenna as RealAntennaDigital).modulator.ModulationBits = ModulationBits;
+
+            if (MultiTransceiver)
+            {
+                Antenna.BandInfo secondaryBand = Antenna.BandInfo.All[SecondaryRFBand];
+                RASecondaryAntenna.TechLevelInfo = RAAntenna.TechLevelInfo;
+                RASecondaryAntenna.TxPower = TxPower;
+                RASecondaryAntenna.RFBand = secondaryBand;
+                RASecondaryAntenna.Duty = AntennaDutyExtensions.FromModeName(SecondaryAntennaDutyMode);
+                RASecondaryAntenna.RFDirection = AntennaRFDirectionExtensions.FromModeName(SecondaryLinkRoleMode);
+                RASecondaryAntenna.SymbolRate = secondaryBand.MaxSymbolRate(techLevel);
+                RASecondaryAntenna.Gain = (antennaDiameter > 0) ? Physics.GainFromDishDiamater(antennaDiameter, secondaryBand.Frequency, RASecondaryAntenna.AntennaEfficiency) : Physics.GainFromReference(referenceGain, referenceFrequency * 1e6f, secondaryBand.Frequency);
+                (RASecondaryAntenna as RealAntennaDigital).modulator.ModulationBits = (RASecondaryAntenna as RealAntennaDigital).modulator.ModulationBitsFromTechLevel(TechLevel);
+            }
+
+            double idleDraw = TotalIdlePowerDraw * 1000;
+            sIdlePowerConsumed = $"{idleDraw:F2} Watts";
+            sActivePowerConsumed = $"{idleDraw + (PowerDrawLinear / 1000):F2} Watts";
 
             RecalculatePlannerECConsumption();
             if (plannerGUI is PlannerGUI)
@@ -262,6 +325,13 @@ namespace RealAntennas
             Fields[nameof(TxPower)].guiActiveEditor = Fields[nameof(TxPower)].guiActive = showFields;
             Fields[nameof(TechLevel)].guiActiveEditor = Fields[nameof(TechLevel)].guiActive = showFields;
             Fields[nameof(RFBand)].guiActiveEditor = Fields[nameof(RFBand)].guiActive = showFields;
+            Fields[nameof(AntennaDutyMode)].guiActiveEditor = Fields[nameof(AntennaDutyMode)].guiActive = showFields;
+            Fields[nameof(LinkRoleMode)].guiActiveEditor = Fields[nameof(LinkRoleMode)].guiActive = showFields;
+            Fields[nameof(MultiTransceiver)].guiActiveEditor = showFields;
+            bool showSecondary = showFields && MultiTransceiver;
+            Fields[nameof(SecondaryRFBand)].guiActiveEditor = Fields[nameof(SecondaryRFBand)].guiActive = showSecondary;
+            Fields[nameof(SecondaryLinkRoleMode)].guiActiveEditor = Fields[nameof(SecondaryLinkRoleMode)].guiActive = showSecondary;
+            Fields[nameof(SecondaryAntennaDutyMode)].guiActiveEditor = Fields[nameof(SecondaryAntennaDutyMode)].guiActive = showSecondary;
             Fields[nameof(sActivePowerConsumed)].guiActiveEditor = Fields[nameof(sActivePowerConsumed)].guiActive = showFields;
             Fields[nameof(sIdlePowerConsumed)].guiActiveEditor = Fields[nameof(sIdlePowerConsumed)].guiActive = showFields;
             Fields[nameof(sAntennaTarget)].guiActive = showFields;
@@ -281,6 +351,12 @@ namespace RealAntennas
             Fields[nameof(TechLevel)].uiControlEditor.onSymmetryFieldChanged = OnTechLevelChangeSymmetry;
             Fields[nameof(RFBand)].uiControlEditor.onFieldChanged = OnRFBandChange;
             Fields[nameof(TxPower)].uiControlEditor.onFieldChanged = OnTxPowerChange;
+            Fields[nameof(AntennaDutyMode)].uiControlEditor.onFieldChanged = OnAntennaDutyChange;
+            Fields[nameof(LinkRoleMode)].uiControlEditor.onFieldChanged = OnLinkRoleChange;
+            Fields[nameof(MultiTransceiver)].uiControlEditor.onFieldChanged = OnMultiTransceiverChange;
+            Fields[nameof(SecondaryRFBand)].uiControlEditor.onFieldChanged = OnSecondaryRFBandChange;
+            Fields[nameof(SecondaryLinkRoleMode)].uiControlEditor.onFieldChanged = OnSecondaryLinkRoleChange;
+            Fields[nameof(SecondaryAntennaDutyMode)].uiControlEditor.onFieldChanged = OnSecondaryAntennaDutyChange;
             Fields[nameof(plannerActiveTxTime)].uiControlEditor.onFieldChanged += OnPlannerActiveTxTimeChanged;
         }
 
@@ -303,6 +379,17 @@ namespace RealAntennas
         }
         private void OnRFBandChange(BaseField f, object obj) => RecalculateFields();
         private void OnTxPowerChange(BaseField f, object obj) => RecalculateFields();
+        private void OnAntennaDutyChange(BaseField f, object obj) => RecalculateFields();
+        private void OnLinkRoleChange(BaseField f, object obj) => RecalculateFields();
+        private void OnMultiTransceiverChange(BaseField f, object obj)
+        {
+            SetFieldVisibility();
+            RecalculateFields();
+            MonoUtilities.RefreshPartContextWindow(part);
+        }
+        private void OnSecondaryRFBandChange(BaseField f, object obj) => RecalculateFields();
+        private void OnSecondaryLinkRoleChange(BaseField f, object obj) => RecalculateFields();
+        private void OnSecondaryAntennaDutyChange(BaseField f, object obj) => RecalculateFields();
         private void OnTechLevelChange(BaseField f, object obj)     // obj is the OLD value
         {
             ApplyTLColoring();
@@ -368,6 +455,36 @@ namespace RealAntennas
             }
         }
 
+        private void ConfigDutyOptions()
+        {
+            UI_ChooseOption op = (UI_ChooseOption)Fields[nameof(AntennaDutyMode)].uiControlEditor;
+            op.options = AntennaDutyExtensions.ModeNames;
+            op.display = AntennaDutyExtensions.ModeDisplayNames;
+            if (op.options.IndexOf(AntennaDutyMode) < 0)
+                AntennaDutyMode = AntennaDutyExtensions.DefaultModeName;
+
+            UI_ChooseOption op2 = (UI_ChooseOption)Fields[nameof(SecondaryAntennaDutyMode)].uiControlEditor;
+            op2.options = AntennaDutyExtensions.ModeNames;
+            op2.display = AntennaDutyExtensions.ModeDisplayNames;
+            if (op2.options.IndexOf(SecondaryAntennaDutyMode) < 0)
+                SecondaryAntennaDutyMode = AntennaDutyExtensions.DefaultModeName;
+        }
+
+        private void ConfigLinkRoleOptions()
+        {
+            UI_ChooseOption op = (UI_ChooseOption)Fields[nameof(LinkRoleMode)].uiControlEditor;
+            op.options = AntennaRFDirectionExtensions.ModeNames;
+            op.display = AntennaRFDirectionExtensions.ModeDisplayNames;
+            if (op.options.IndexOf(LinkRoleMode) < 0)
+                LinkRoleMode = AntennaRFDirectionExtensions.DefaultModeName;
+
+            UI_ChooseOption op2 = (UI_ChooseOption)Fields[nameof(SecondaryLinkRoleMode)].uiControlEditor;
+            op2.options = AntennaRFDirectionExtensions.ModeNames;
+            op2.display = AntennaRFDirectionExtensions.ModeDisplayNames;
+            if (op2.options.IndexOf(SecondaryLinkRoleMode) < 0)
+                SecondaryLinkRoleMode = AntennaRFDirectionExtensions.DefaultModeName;
+        }
+
         private void ConfigBandOptions()
         {
             List<string> availableBands = new List<string>();
@@ -383,6 +500,12 @@ namespace RealAntennas
             op.display = availableBandDisplayNames.ToArray();
             if (op.options.IndexOf(RFBand) < 0)
                 RFBand = op.options[op.options.Length - 1];
+
+            UI_ChooseOption op2 = (UI_ChooseOption)Fields[nameof(SecondaryRFBand)].uiControlEditor;
+            op2.options = availableBands.ToArray();
+            op2.display = availableBandDisplayNames.ToArray();
+            if (op2.options.IndexOf(SecondaryRFBand) < 0)
+                SecondaryRFBand = op2.options[op2.options.Length - 1];
         }
 
         public override string GetModuleDisplayName() => "RealAntenna";
@@ -400,6 +523,15 @@ namespace RealAntennas
             {
                 res = $"<color=green>Omni-directional</color>: {Gain:F1} dBi";
             }
+            res += $"\nAntenna Duty: <color=green>{AntennaDutyExtensions.ModeDisplayNames[Array.IndexOf(AntennaDutyExtensions.ModeNames, AntennaDutyMode)]}</color> (changeable in editor)";
+            res += $"\nLink Direction: <color=green>{AntennaRFDirectionExtensions.ModeDisplayNames[Array.IndexOf(AntennaRFDirectionExtensions.ModeNames, LinkRoleMode)]}</color>";
+            if (MultiTransceiver)
+            {
+                res += $"\n<color=cyan><b>Dual-Band Transceiver</b></color>";
+                res += $"\n  Secondary Band: <color=green>{SecondaryRFBand}-Band</color>";
+                res += $"\n  Secondary Duty: <color=green>{AntennaDutyExtensions.ModeDisplayNames[Array.IndexOf(AntennaDutyExtensions.ModeNames, SecondaryAntennaDutyMode)]}</color>";
+                res += $"\n  Secondary Direction: <color=green>{AntennaRFDirectionExtensions.ModeDisplayNames[Array.IndexOf(AntennaRFDirectionExtensions.ModeNames, SecondaryLinkRoleMode)]}</color>";
+            }
             return res;
         }
 
@@ -416,7 +548,9 @@ namespace RealAntennas
         {
             if (RACommNetScenario.CommNetEnabled && this?.vessel?.Connection?.Comm is RACommNode node)
             {
-                double data_rate = (node.Net as RACommNetwork).MaxDataRateToHome(node);
+                // Use the Science-capable path, not the general one - they can
+                // legitimately differ if the best path crosses a Telemetry-only hop.
+                double data_rate = (node.Net as RACommNetwork).MaxScienceDataRateToHome(node);
                 packetInterval = DefaultPacketInterval;
                 packetSize = Convert.ToSingle(data_rate * packetInterval);
                 packetSize *= StockRateModifier;
@@ -427,11 +561,27 @@ namespace RealAntennas
         public override bool CanTransmit()
         {
             SetTransmissionParams();
+            if (!AnyTransceiverCanHandleScience)
+                return false;
             return base.CanTransmit();
+        }
+
+        // True if the primary or (if dual-band) secondary transceiver can
+        // carry Science.
+        private bool AnyTransceiverCanHandleScience =>
+            RAAntenna.CanHandleScience || (MultiTransceiver && RASecondaryAntenna != null && RASecondaryAntenna.CanHandleScience);
+
+        private bool RejectIfScienceNotAllowed()
+        {
+            if (AnyTransceiverCanHandleScience) return false;
+            ScreenMessages.PostScreenMessage($"{part.partInfo.title} is set to Telemetry-only and cannot transmit science data. Switch its Antenna Duty to Science or Both.", 6f, ScreenMessageStyle.UPPER_CENTER);
+            Debug.LogWarning($"{ModTag} Blocked science transmission on {part.partInfo.title}: Antenna Duty = {AntennaDutyMode}");
+            return true;
         }
 
         public override void TransmitData(List<ScienceData> dataQueue)
         {
+            if (RejectIfScienceNotAllowed()) return;
             SetTransmissionParams();
             base.TransmitData(dataQueue);
             if (!scienceMonitorActive)
@@ -440,6 +590,11 @@ namespace RealAntennas
 
         public override void TransmitData(List<ScienceData> dataQueue, Callback callback)
         {
+            if (RejectIfScienceNotAllowed())
+            {
+                callback?.Invoke();
+                return;
+            }
             SetTransmissionParams();
             base.TransmitData(dataQueue, callback);
             if (!scienceMonitorActive)
@@ -479,9 +634,13 @@ namespace RealAntennas
 
         #region Cost and Mass Modifiers
         public float GetModuleCost(float defaultCost, ModifierStagingSituation sit) =>
-            Condition != AntennaCondition.Disabled ? RAAntenna.TechLevelInfo.BaseCost + (RAAntenna.TechLevelInfo.CostPerWatt * RATools.LinearScale(TxPower)/1000) : 0;
+            Condition != AntennaCondition.Disabled
+                ? (RAAntenna.TechLevelInfo.BaseCost + (RAAntenna.TechLevelInfo.CostPerWatt * RATools.LinearScale(TxPower) / 1000)) * (MultiTransceiver ? multiTransceiverCostMult : 1f)
+                : 0;
         public float GetModuleMass(float defaultMass, ModifierStagingSituation sit) =>
-            Condition != AntennaCondition.Disabled && applyMassModifier ? (RAAntenna.TechLevelInfo.BaseMass + (RAAntenna.TechLevelInfo.MassPerWatt * RATools.LinearScale(TxPower) / 1000)) / 1000 : 0;
+            Condition != AntennaCondition.Disabled && applyMassModifier
+                ? ((RAAntenna.TechLevelInfo.BaseMass + (RAAntenna.TechLevelInfo.MassPerWatt * RATools.LinearScale(TxPower) / 1000)) / 1000) * (MultiTransceiver ? multiTransceiverMassMult : 1f)
+                : 0;
         public ModifierChangeWhen GetModuleCostChangeWhen() => ModifierChangeWhen.FIXED;
         public ModifierChangeWhen GetModuleMassChangeWhen() => ModifierChangeWhen.FIXED;
         #endregion
@@ -497,7 +656,7 @@ namespace RealAntennas
         {
             bool consumesPower = Condition != AntennaCondition.Disabled && Condition != AntennaCondition.PermanentShutdown;
             // RAAntenna.IdlePowerDraw is in kW (ec/s), PowerDrawLinear is in mW
-            double ec = consumesPower ? RAAntenna.IdlePowerDraw + (RAAntenna.PowerDrawLinear * 1e-6 * plannerActiveTxTime) : 0;
+            double ec = consumesPower ? TotalIdlePowerDraw + (RAAntenna.PowerDrawLinear * 1e-6 * plannerActiveTxTime) : 0;
             plannerECConsumption = new KeyValuePair<string, double>("ElectricCharge", -ec);
         }
 

--- a/src/RealAntennasProject/PlannerGUI.cs
+++ b/src/RealAntennasProject/PlannerGUI.cs
@@ -1,4 +1,4 @@
-﻿using ClickThroughFix;
+using ClickThroughFix;
 using System;
 using System.Collections.Generic;
 using UniLinq;
@@ -156,7 +156,7 @@ namespace RealAntennas
             GUILayout.EndHorizontal();
             GUILayout.EndVertical();
 
-            if (!primaryAntenna.Compatible(fixedAntenna) && fixedAntenna.ParentNode is RACommNode raNode && raNode.RAAntennaList.FirstOrDefault(x => x.Compatible(primaryAntenna)) is RealAntenna ra)
+            if (!primaryAntenna.EitherDirectionCompatible(fixedAntenna) && fixedAntenna.ParentNode is RACommNode raNode && raNode.RAAntennaList.FirstOrDefault(x => x.EitherDirectionCompatible(primaryAntenna)) is RealAntenna ra)
             {
                 ScreenMessages.PostScreenMessage($"{fixedAntenna.ParentNode.displayName} {fixedAntenna.Name} band changed from {fixedAntenna.RFBand.name} to {ra.RFBand.name} to match with {primaryAntenna.Name} band", 2, ScreenMessageStyle.UPPER_CENTER);
                 fixedAntenna = ra;
@@ -216,6 +216,10 @@ namespace RealAntennas
             foreach (var s in rateStrings)
                 GUILayout.Label(s);
 
+            float minUplinkRateSetting = HighLogic.CurrentGame.Parameters.CustomParams<RAParameters>().MinControlUplinkBitRate;
+            if (minUplinkRateSetting > 0)
+                GUILayout.Label($"Difficulty setting - Min. Uplink for Control: {RATools.PrettyPrintDataRate(minUplinkRateSetting)}");
+
             GUILayout.EndVertical();
 
             GUILayout.Space(SPACING);
@@ -256,11 +260,20 @@ namespace RealAntennas
                     ShipConstruct sc = EditorLogic.RootPart.ship;
                     foreach (Part p in sc.Parts)
                         foreach (ModuleRealAntenna mra in p.FindModulesImplementing<ModuleRealAntenna>())
+                        {
                             if (GUILayout.Button($"{sc.shipName} {mra.RAAntenna.ToStringShort()}", buttonStyle))
                             {
                                 antenna = mra.RAAntenna;
                                 res = true;
                             }
+                            // dual-band parts have a second, independent
+                            // transceiver that needs to be individually selectable too.
+                            if (mra.MultiTransceiver && GUILayout.Button($"{sc.shipName} {mra.RASecondaryAntenna.ToStringShort()}", buttonStyle))
+                            {
+                                antenna = mra.RASecondaryAntenna;
+                                res = true;
+                            }
+                        }
 
                     foreach (var x in protoVesselAntennaCache)
                         foreach (RealAntenna ra in x.Value)
@@ -305,7 +318,7 @@ namespace RealAntennas
         {
             List<RealAntenna> antennas = new List<RealAntenna>();
             foreach (Network.RACommNetHome home in stations) 
-                foreach (RealAntenna ra in home.Comm.RAAntennaList.Where(x => x.Compatible(peer))) 
+                foreach (RealAntenna ra in home.Comm.RAAntennaList.Where(x => x.EitherDirectionCompatible(peer))) 
                     antennas.Add(ra);
 
             if (ascending) 
@@ -318,7 +331,7 @@ namespace RealAntennas
         {
             RealAntenna best = null;
             foreach (var station in stations)
-                foreach (RealAntenna ra in station.Comm.RAAntennaList.Where(x => x.Compatible(peer)))
+                foreach (RealAntenna ra in station.Comm.RAAntennaList.Where(x => x.EitherDirectionCompatible(peer)))
                 {
                     best ??= ra;
                     best = (best.Gain > ra.Gain) ? best : ra;
@@ -339,6 +352,17 @@ namespace RealAntennas
                         RealAntenna ra = new RealAntennaDigital(part.partInfo.title) { ParentNode = null };
                         ra.LoadFromConfigNode(snap.moduleValues);
                         antennas.Add(ra);
+
+                        bool multiTransceiver = false;
+                        snap.moduleValues.TryGetValue(nameof(ModuleRealAntenna.MultiTransceiver), ref multiTransceiver);
+                        if (multiTransceiver)
+                        {
+                            RealAntenna ra2 = new RealAntennaDigital($"{part.partInfo.title} (Secondary)") { ParentNode = null };
+                            ra2.LoadSecondaryFromConfigNode(snap.moduleValues);
+                            // One dish, one target - see the same note in RACommNetVessel.
+                            if (ra2.CanTarget) ra2.Target = ra.Target;
+                            antennas.Add(ra2);
+                        }
                     }
                 }
                 if (antennas.Count > 0)
@@ -363,6 +387,16 @@ namespace RealAntennas
             else if (distance > 1e6) siSelector = 1;
             else siSelector = 0;
             val = distance / Math.Pow(1e3, siSelector + 1);
+        }
+
+        
+        // Describes the connection state for one direction-pair of rates.
+        private static string ConnectionNote(float downlinkRate, float uplinkRate)
+        {
+            if (downlinkRate == 0 && uplinkRate == 0) return $"  {sNoConnection}";
+            if (downlinkRate == 0) return "  <color=yellow>(Uplink only - no downlink)</color>";
+            if (uplinkRate == 0) return "  <color=yellow>(Downlink only - no uplink)</color>";
+            return string.Empty;
         }
 
         private void FireOnce()
@@ -440,6 +474,15 @@ namespace RealAntennas
             precompute.DoThings(bodies, nodes, true);
             precompute.SimulateComplete(ref net.connectionDebugger, nodes, log: false);
 
+            // Snapshot how many debug-info entries exist after the NEAR run, so we
+            // can tell near-distance entries apart from far-distance ones below
+            // without assuming a fixed count/order per distance. That assumption
+            // (exactly 2 entries per distance, one per direction) breaks as soon as
+            // an antenna is Duty- or RFDirection-restricted to only one direction,
+            // since then only 1 entry (not 2) gets added per distance.
+            connectionDebugger.items.TryGetValue(fixedAntennaCopy, out var resultsAfterNear);
+            int nearEntryCount = resultsAfterNear?.Count ?? 0;
+
             nodes = new List<CommNet.CommNode> { fixedNode, primaryFarNode };
             peerAntennaCopy.ParentNode = primaryFarNode;
             net.connectionDebugger = connectionDebugger;
@@ -451,21 +494,40 @@ namespace RealAntennas
             net.connectionDebugger = debugger;
             rateStrings.Clear();
             connectionDebugger.visible[fixedAntennaCopy] = debuggerDisplayState;
-            if (connectionDebugger.items.TryGetValue(fixedAntennaCopy, out var results))
+            connectionDebugger.items.TryGetValue(fixedAntennaCopy, out var allResults);
+            if (allResults != null)
             {
-                int i = 0;
-                float[] rates = { 0, 0, 0, 0 };
-                foreach (var res in results)
+                // res.tx == peerAntennaCopy means the peer is transmitting, ie the
+                // downlink (peer -> fixed) direction. Otherwise fixed is
+                // transmitting, ie the uplink/command (fixed -> peer) direction.
+                // Either or both may be entirely absent for a one-directional
+                // (Uplink-only/Downlink-only) antenna
+                float nearDown = 0, nearUp = 0, farDown = 0, farUp = 0;
+                for (int idx = 0; idx < allResults.Count; idx++)
                 {
-                    int txInd = res.tx == fixedAntennaCopy ? 1 : 0;
-                    int index = 2 * (i / 2) + txInd;  // Integer math: 1 / 2 = 0
-                    rates[index] = res.dataRate;    // 0 = Near Tx.  3 = Far Rx.
-                    i++;
+                    var res = allResults[idx];
+                    bool isNear = idx < nearEntryCount;
+                    bool isDownlink = res.tx == peerAntennaCopy;
+                    if (isNear && isDownlink) nearDown = res.dataRate;
+                    else if (isNear) nearUp = res.dataRate;
+                    else if (isDownlink) farDown = res.dataRate;
+                    else farUp = res.dataRate;
                 }
-                string sMax = $"Tx/Rx rate at max distance: {RATools.PrettyPrintDataRate(rates[2])}/{RATools.PrettyPrintDataRate(rates[3])}";
-                string sMin = $"Tx/Rx rate at min distance: {RATools.PrettyPrintDataRate(rates[0])}/{RATools.PrettyPrintDataRate(rates[1])}";
-                if (rates[2] == 0 || rates[3] == 0) sMax += $"  {sNoConnection}";
-                if (rates[0] == 0 || rates[1] == 0) sMin += $"  {sNoConnection}";
+
+                string sMax = $"Tx/Rx rate at max distance: {RATools.PrettyPrintDataRate(farDown)}/{RATools.PrettyPrintDataRate(farUp)}";
+                string sMin = $"Tx/Rx rate at min distance: {RATools.PrettyPrintDataRate(nearDown)}/{RATools.PrettyPrintDataRate(nearUp)}";
+                sMax += ConnectionNote(farDown, farUp);
+                sMin += ConnectionNote(nearDown, nearUp);
+
+                // "Rx" here is the peer receiving, ie the command uplink
+                // (Kerbin/relay -> peer) - compare it against the difficulty-set
+                // minimum uplink rate for probe control.
+                float minUplinkRate = HighLogic.CurrentGame.Parameters.CustomParams<RAParameters>().MinControlUplinkBitRate;
+                if (minUplinkRate > 0)
+                {
+                    if (farUp > 0) sMax += (farUp >= minUplinkRate) ? "  <color=lime>[Uplink OK for control]</color>" : "  <color=orange>[Uplink below control minimum]</color>";
+                    if (nearUp > 0) sMin += (nearUp >= minUplinkRate) ? "  <color=lime>[Uplink OK for control]</color>" : "  <color=orange>[Uplink below control minimum]</color>";
+                }
 
                 rateStrings.Add(sMax);
                 rateStrings.Add(sMin);

--- a/src/RealAntennasProject/Precompute/Jobs.cs
+++ b/src/RealAntennasProject/Precompute/Jobs.cs
@@ -1,4 +1,4 @@
-﻿using Unity.Burst;
+using Unity.Burst;
 using Unity.Collections;
 using Unity.Jobs;
 using Unity.Mathematics;

--- a/src/RealAntennasProject/Precompute/Precompute.cs
+++ b/src/RealAntennasProject/Precompute/Precompute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Unity.Collections;
 using Unity.Jobs;
@@ -453,43 +453,39 @@ namespace RealAntennas.Precompute
                 if (pair.x <= pair.y && pair.y < RACN.Nodes.Count)
                 {
                     var p2 = new int2(pair.y, pair.x);
-                    if (validMap.TryGetValue(pair, out bool valid) && valid &&
-                        validMap.TryGetValue(p2, out bool valid2) && valid2 &&
-                        bestMap.TryGetValue(pair, out int row) &&
-                        bestMap.TryGetValue(p2, out int row2) &&
-                        row >= 0 && row2 >= 0 &&
-                        dataRate[row] > 0 && dataRate[row2] > 0)
+                    int row = -1, row2 = -1;
+                    bool fwdValid = validMap.TryGetValue(pair, out bool valid) && valid
+                        && bestMap.TryGetValue(pair, out row) && row >= 0 && dataRate[row] > 0;
+                    bool revValid = validMap.TryGetValue(p2, out bool valid2) && valid2
+                        && bestMap.TryGetValue(p2, out row2) && row2 >= 0 && dataRate[row2] > 0;
+                    if (fwdValid || revValid)
                     {
                         // Connect Successful
                         RACommNode a = RACN.Nodes[pair.x] as RACommNode;
                         RACommNode b = RACN.Nodes[pair.y] as RACommNode;
-                        int4 fwdQuad = allValidAntennaPairs[row];
-                        int4 revQuad = allValidAntennaPairs[row2];
-                        /*
-                        RealAntenna fwdTx = allAntennasReverse[fwdQuad.z];
-                        RealAntenna fwdRx = allAntennasReverse[fwdQuad.w];
-                        RealAntenna revTx = allAntennasReverse[revQuad.z];
-                        RealAntenna revRx = allAntennasReverse[revQuad.w];
-                        double fwd = dataRate[row];
-                        double rev = dataRate[row2];
-                        double FwdBestDataRate = maxDataRate[row];
-                        double RevBestDataRate = maxDataRate[row2];
-                        */
-                        double FwdMetric = 1.0 - ((float)rateSteps[row] / (maxSteps[row] + 1));
-                        double RevMetric = 1.0 - ((float)rateSteps[row2] / (maxSteps[row2] + 1));
-                        //RACN.MakeLink(fwdTx, fwdRx, revTx, revRx, a, b, (a.position - b.position).magnitude, fwd, rev, FwdBestDataRate, FwdMetric, RevMetric);
-                        RACN.MakeLink(allAntennasReverse[fwdQuad.z],
-                            allAntennasReverse[fwdQuad.w],
-                            allAntennasReverse[revQuad.z],
-                            allAntennasReverse[revQuad.w],
+                        RealAntenna fwdTx = fwdValid ? allAntennasReverse[allValidAntennaPairs[row].z] : null;
+                        RealAntenna fwdRx = fwdValid ? allAntennasReverse[allValidAntennaPairs[row].w] : null;
+                        RealAntenna revTx = revValid ? allAntennasReverse[allValidAntennaPairs[row2].z] : null;
+                        RealAntenna revRx = revValid ? allAntennasReverse[allValidAntennaPairs[row2].w] : null;
+                        double FwdRate = fwdValid ? dataRate[row] : 0;
+                        double RevRate = revValid ? dataRate[row2] : 0;
+                        double FwdBestDataRate = fwdValid ? maxDataRate[row] : 0;
+                        double FwdMetric = fwdValid ? 1.0 - ((float)rateSteps[row] / (maxSteps[row] + 1)) : 0;
+                        double RevMetric = revValid ? 1.0 - ((float)rateSteps[row2] / (maxSteps[row2] + 1)) : 0;
+                        RACN.MakeLink(fwdTx,
+                            fwdRx,
+                            revTx,
+                            revRx,
                             a,
                             b,
                             (a.position - b.position).magnitude,
-                            dataRate[row],
-                            dataRate[row2],
-                            maxDataRate[row],
+                            FwdRate,
+                            RevRate,
+                            FwdBestDataRate,
                             FwdMetric,
-                            RevMetric);
+                            RevMetric,
+                            fwdValid,
+                            revValid);
                     } else
                     {
                         RACN.DoDisconnect(RACN.Nodes[pair.x], RACN.Nodes[pair.y]);

--- a/src/RealAntennasProject/RACommNetVessel.cs
+++ b/src/RealAntennasProject/RACommNetVessel.cs
@@ -1,4 +1,4 @@
-﻿using Expansions.Serenity.DeployedScience.Runtime;
+using Expansions.Serenity.DeployedScience.Runtime;
 using Experience.Effects;
 using KSPCommunityFixes;
 using System;
@@ -222,6 +222,18 @@ namespace RealAntennas
                             if (DeployedLoaded(ant.part)) antennaList.Add(ant.RAAntenna);
                             else inactiveAntennas.Add(ant.RAAntenna);
                             ValidateAntennaTarget(ant.RAAntenna);
+
+                            // The secondary transceiver is an independent RealAntenna
+                            // for network purposes, so it gets its own list entry.
+                            // It mirrors the primary's target rather than having its own
+                            if (ant.MultiTransceiver && ant.RASecondaryAntenna != null)
+                            {
+                                ant.RASecondaryAntenna.ParentNode = Comm;
+                                if (DeployedLoaded(ant.part)) antennaList.Add(ant.RASecondaryAntenna);
+                                else inactiveAntennas.Add(ant.RASecondaryAntenna);
+                                if (ant.RASecondaryAntenna.CanTarget)
+                                    ant.RASecondaryAntenna.Target = ant.RAAntenna.Target;
+                            }
                         }
                     }
                 }
@@ -248,6 +260,22 @@ namespace RealAntennas
                             if (DeployedUnloaded(part)) antennaList.Add(ra);
                             else inactiveAntennas.Add(ra);
                             ValidateAntennaTarget(ra);
+
+                            bool multiTransceiver = false;
+                            snap.moduleValues.TryGetValue(nameof(ModuleRealAntenna.MultiTransceiver), ref multiTransceiver);
+                            if (multiTransceiver)
+                            {
+                                RealAntenna ra2 = new RealAntennaDigital($"{part.partPrefab.partInfo.title} (Secondary)") { ParentNode = Comm, ParentSnapshot = snap };
+                                ra2.LoadSecondaryFromConfigNode(snap.moduleValues);
+                                if (DeployedUnloaded(part)) antennaList.Add(ra2);
+                                else inactiveAntennas.Add(ra2);
+                                // No .Parent here (unloaded vessel, no live PartModule),
+                                // so the Target-setter propagation can't fire - mirror
+                                // explicitly instead of validating ra2 independently,
+                                // for the same one-dish-one-target reason as above.
+                                if (ra2.CanTarget)
+                                    ra2.Target = ra.Target;
+                            }
                         }
                     }
                 }

--- a/src/RealAntennasProject/RACommNetwork.cs
+++ b/src/RealAntennasProject/RACommNetwork.cs
@@ -1,4 +1,4 @@
-﻿using CommNet;
+using CommNet;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -64,7 +64,9 @@ namespace RealAntennas
                                double RevDataRate,
                                double FwdBestDataRate,
                                double FwdMetric,
-                               double RevMetric
+                               double RevMetric,
+                               bool fwdValid = true,
+                               bool revValid = true
                                )
         {
             RACommLink link = Connect(a, b, distance) as RACommLink;
@@ -78,13 +80,20 @@ namespace RealAntennas
             link.RevAntennaRx = revRx;
             link.FwdDataRate = FwdDataRate;
             link.RevDataRate = RevDataRate;
-            link.cost = link.CostFunc((FwdDataRate + RevDataRate) / 2);
+            
+            // Only average across directions that actually exist - otherwise
+            // legitimately absent direction would halve the apparent rate.
+            double avgRateForCost = (fwdValid && revValid) ? (FwdDataRate + RevDataRate) / 2 : (fwdValid ? FwdDataRate : RevDataRate);
+            link.cost = link.CostFunc(avgRateForCost);
             link.FwdMetric = FwdMetric;
             link.RevMetric = RevMetric;
             if (FwdBestDataRate < FwdDataRate)
                 Debug.LogWarning($"{ModTag} Detected actual rate {FwdDataRate} greater than expected max {FwdBestDataRate} for antennas {link.FwdAntennaTx} and {link.FwdAntennaRx}");
 
-            link.Update(Math.Min(link.FwdMetric, link.RevMetric));
+            // Same reasoning: Math.Min would zero out the signal strength of a
+            // good one-directional link, since the missing side's metric is 0.
+            double signalMetric = (fwdValid && revValid) ? Math.Min(link.FwdMetric, link.RevMetric) : (fwdValid ? link.FwdMetric : link.RevMetric);
+            link.Update(signalMetric);
         }
 
         protected override CommLink Connect(CommNode a, CommNode b, double distance)
@@ -128,6 +137,34 @@ namespace RealAntennas
             }
             return data_rate;
         }
+
+
+
+
+
+
+        // Data rate along a path to home that's usable for Science end to end
+        // (see FindScienceCapableHome), not just the general best/control path.
+        // If the best path crosses a Telemetry-only hop, this searches for a
+        // fully Science-capable alternate route instead of reporting 0. Used by
+        // the Kerbalism bridge, which bypasses ModuleRealAntenna's own duty check.
+        public double MaxScienceDataRateToHome(RACommNode start)
+        {
+            if (start == null) return 0;
+            CommPath path = new CommPath();
+            if (!FindScienceCapableHome(start, path)) return 0;
+            double data_rate = double.MaxValue;
+            foreach (CommLink l in path)
+            {
+                RACommLink link = l.start[l.end] as RACommLink;
+                double linkRate = link.start.Equals(l.start) ? link.FwdDataRate : link.RevDataRate;
+                data_rate = Math.Min(data_rate, linkRate);
+            }
+            return data_rate == double.MaxValue ? 0 : data_rate;
+        }
+
+        public bool PathCanCarryScience(RACommNode start) => MaxScienceDataRateToHome(start) > 0;
+
         private bool calculating = false;
 
         private bool IsPaused => (KSCPauseMenu.Instance && KSCPauseMenu.Instance.enabled) || (PauseMenu.exists && PauseMenu.isOpen);
@@ -275,6 +312,50 @@ namespace RealAntennas
             Debug.Log(CommLinkWalk());
         }
 
+        // findhome for recieve only craft
+        public override bool FindHome(CommNode start, CommPath path)
+        {
+            if (base.FindHome(start, path))
+                return true;
+            if (currentPurpose != PathPurpose.General || !(start is RACommNode racn) || HasTelemetryCapableTransmitAntenna(racn))
+                return false;
+
+            foreach (var home in RACommNetScenario.EnabledStations)
+            {
+                if (!(home.Comm is RACommNode homeNode)) continue;
+                CommPath reversePath = new CommPath();
+                CommNode foundReverse;
+                searchingFromHome = true;
+                try
+                {
+                    foundReverse = FindClosestWhere(homeNode, reversePath, (s, c) => c == start);
+                }
+                finally
+                {
+                    searchingFromHome = false;
+                }
+                if (foundReverse != null)
+                {
+                    foreach (CommLink l in reversePath)
+                        if (l is RACommLink racLink) racLink.SwapEnds();
+                    reversePath.Reverse();
+                    path?.Clear();
+                    path?.AddRange(reversePath);
+                    path?.UpdateFromPath();
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        
+        private bool searchingFromHome = false;
+
+        // the fallback should only trigger when the craft has
+        // no way to originate a CONTROL-carrying transmission
+        private static bool HasTelemetryCapableTransmitAntenna(RACommNode node) =>
+            node.RAAntennaList != null && node.RAAntennaList.Any(ra => ra.CanTransmitRF && ra.CanHandleTelemetry);
+
         #region Pathfinding
         /*
         public override bool FindPath(CommNode start, CommPath path, CommNode end)
@@ -282,6 +363,24 @@ namespace RealAntennas
             return base.FindPath(start, path, end);
         }
         */
+
+        
+        public enum PathPurpose { General, ScienceCapable }
+        private PathPurpose currentPurpose = PathPurpose.General;
+
+        
+        public bool FindScienceCapableHome(RACommNode start, CommPath path)
+        {
+            currentPurpose = PathPurpose.ScienceCapable;
+            try
+            {
+                return FindHome(start, path);
+            }
+            finally
+            {
+                currentPurpose = PathPurpose.General;
+            }
+        }
 
         private readonly HashSet<RACommNode> sptSet = new HashSet<RACommNode>();
         private readonly List<RACommNode> pathSortList = new List<RACommNode>();
@@ -295,6 +394,9 @@ namespace RealAntennas
             path?.Clear();
             sptSet.Clear();
             pathSortList.Clear();
+            float minControlUplinkRate = currentPurpose == PathPurpose.General
+                ? HighLogic.CurrentGame.Parameters.CustomParams<RAParameters>().MinControlUplinkBitRate
+                : 0f;
             foreach (RACommNode racn in Nodes)
             {
                 racn.bestCost = (racn == start) ? 0 : double.PositiveInfinity;
@@ -314,19 +416,37 @@ namespace RealAntennas
                 {
                     foreach (KeyValuePair<CommNode, CommLink> kvp in candidate)
                     {
-                        if (kvp.Key is RACommNode node && kvp.Value is RACommLink link && !sptSet.Contains(node)
-                            && (link.start == candidate ? link.FwdAntennaRx : link.RevAntennaRx) is RealAntenna rxAntenna
-                            // Skip if the peer is unable to relay and is also not the destination
-                            && (rxAntenna.TechLevelInfo.Level >= RACommNetScenario.minRelayTL || where(start, node)))
+                        if (kvp.Key is RACommNode node && kvp.Value is RACommLink link && !sptSet.Contains(node))
                         {
-                            double cost = link.start == candidate ? link.FwdCost : link.RevCost;
-                            if (node.bestCost > candidate.bestCost + cost)
+                            bool forward = link.start == candidate;
+                            RealAntenna txAntenna = forward ? link.FwdAntennaTx : link.RevAntennaTx;
+                            RealAntenna rxAntenna = forward ? link.FwdAntennaRx : link.RevAntennaRx;
+                            
+                            double uplinkRateThisHop = searchingFromHome
+                                ? (forward ? link.FwdDataRate : link.RevDataRate)
+                                : (forward ? link.RevDataRate : link.FwdDataRate);
+
+                            
+                            bool relayOk = rxAntenna is RealAntenna
+                                && (rxAntenna.TechLevelInfo.Level >= RACommNetScenario.minRelayTL || where(start, node));
+                            bool scienceOk = currentPurpose != PathPurpose.ScienceCapable
+                                || (txAntenna is RealAntenna && rxAntenna is RealAntenna && txAntenna.CanHandleScience && rxAntenna.CanHandleScience);
+                            
+                            bool telemetryOk = currentPurpose != PathPurpose.General
+                                || (txAntenna is RealAntenna && rxAntenna is RealAntenna && txAntenna.CanHandleTelemetry && rxAntenna.CanHandleTelemetry);
+                            bool uplinkOk = minControlUplinkRate <= 0 || uplinkRateThisHop >= minControlUplinkRate;
+
+                            if (relayOk && scienceOk && telemetryOk && uplinkOk)
                             {
-                                node.bestCost = candidate.bestCost + cost;
-                                node.bestLink = link;
-                                node.bestLinkNode = candidate;
+                                double cost = forward ? link.FwdCost : link.RevCost;
+                                if (node.bestCost > candidate.bestCost + cost)
+                                {
+                                    node.bestCost = candidate.bestCost + cost;
+                                    node.bestLink = link;
+                                    node.bestLinkNode = candidate;
+                                }
+                                pathSortList.AddUnique(node);
                             }
-                            pathSortList.AddUnique(node);
                         }
                     }
                 }

--- a/src/RealAntennasProject/RAParameters.cs
+++ b/src/RealAntennasProject/RAParameters.cs
@@ -1,4 +1,4 @@
-﻿namespace RealAntennas
+namespace RealAntennas
 {
     class RAParameters : GameParameters.CustomParameterNode
     {
@@ -30,17 +30,25 @@
         [GameParameters.CustomFloatParameterUI("Rescale transmission rate for stock science", toolTip = "Multiplier to transmission rate for stock science.  Available for balancing purposes: turn it down if science transmits too quickly, or up if too slowly.", minValue = 0.00001f, maxValue = 0.01f, stepCount = 10000, displayFormat = "N5")]
         public float StockRateModifier = 0.01f;
 
+        [GameParameters.CustomFloatParameterUI("Min. Uplink Bit Rate for Probe Control (bps)", toolTip = "The command uplink (Kerbin/relay -> craft) needs at least this data rate for the Antenna Planner to consider the link usable for probe control. 0 = no minimum. NOTE: currently advisory only in the Planner - not yet enforced in flight.", minValue = 0f, maxValue = 2000f, stepCount = 400, displayFormat = "N0")]
+        public float MinControlUplinkBitRate = 0f;
+
         public override void SetDifficultyPreset(GameParameters.Preset preset)
         {
             switch (preset)
             {
                 case GameParameters.Preset.Easy:
                     enforceMinDirectionalDistance = false;
+                    MinControlUplinkBitRate = 0;
                     break;
                 case GameParameters.Preset.Normal:
                 case GameParameters.Preset.Moderate:
+                    enforceMinDirectionalDistance = true;
+                    MinControlUplinkBitRate = 0;
+                    break;
                 case GameParameters.Preset.Hard:
                     enforceMinDirectionalDistance = true;
+                    MinControlUplinkBitRate = 8;
                     break;
             }
         }

--- a/src/RealAntennasProject/RealAntenna.cs
+++ b/src/RealAntennasProject/RealAntenna.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using UnityEngine;
 
@@ -28,6 +28,17 @@ namespace RealAntennas
         public virtual float AMWTemp { get; set; }
         public virtual float Beamwidth => Physics.Beamwidth(Gain);
         public virtual string EncoderOverride { get; set; }
+
+        // Science vs Telemetry duty toggle.
+        public virtual AntennaDuty Duty { get; set; } = AntennaDuty.Both;
+        public bool CanHandleTelemetry => Duty.CanHandleTelemetry();
+        public bool CanHandleScience => Duty.CanHandleScience();
+
+        // restrict this transceiver to only transmitting or only
+        // receiving RF (eg a deliberately low-rate, receive-only uplink chain).
+        public virtual AntennaRFDirection RFDirection { get; set; } = AntennaRFDirection.Bidirectional;
+        public bool CanTransmitRF => RFDirection.CanTransmitRF();
+        public bool CanReceiveRF => RFDirection.CanReceiveRF();
 
         public Antenna.Encoder Encoder => Antenna.Encoder.GetFromName(EncoderOverride) ?? Antenna.Encoder.GetFromTechLevel(TechLevelInfo.Level);
         public virtual float RequiredCI => Encoder.RequiredEbN0;
@@ -60,6 +71,15 @@ namespace RealAntennas
                     snap.moduleValues.RemoveNode(Targeting.AntennaTarget.nodeName);
                     _target.Save(snap.moduleValues);
                 }
+                
+                // A dish is one physical piece of hardware, so a Dual-Band part's two
+                // transceivers must point the same way. Mirror the primary's target
+                // onto the secondary whenever it changes.
+                if (Parent is ModuleRealAntenna parentModule && ReferenceEquals(parentModule.RAAntenna, this)
+                    && parentModule.RASecondaryAntenna is RealAntenna secondary && !ReferenceEquals(secondary, this))
+                {
+                    secondary.Target = _target;
+                }
             }
         }
 
@@ -73,7 +93,13 @@ namespace RealAntennas
         private readonly float minimumSpotRadius = 1e3f;
 
         public override string ToString() => $"{Name} [{RFBand.name} {Gain:F1} dBi {TxPower} dBm [TL:{TechLevelInfo.Level:N0}]] {(CanTarget ? $" ->{Target}" : null)}";
-        public virtual string ToStringShort() => $"{Name} [{RFBand.name} {TxPower} dBm] {(CanTarget ? $" ->{Target}" : null)}";
+        public virtual string ToStringShort()
+        {
+            string modeSuffix = string.Empty;
+            if (Duty != AntennaDuty.Both) modeSuffix += $" [{Duty.ToModeName()}]";
+            if (RFDirection != AntennaRFDirection.Bidirectional) modeSuffix += $" [{(RFDirection.CanTransmitRF() ? "Downlink" : "Uplink")}]";
+            return $"{Name} [{RFBand.name} {TxPower} dBm]{modeSuffix} {(CanTarget ? $" ->{Target}" : null)}";
+        }
 
         public RealAntenna() : this("New RealAntennaDigital") { }
         public RealAntenna(string name, double dataRate = 1000)
@@ -100,9 +126,15 @@ namespace RealAntennas
             ParentNode = orig.ParentNode;
             ParentSnapshot = orig.ParentSnapshot;
             EncoderOverride = orig.EncoderOverride;
+            Duty = orig.Duty;
+            RFDirection = orig.RFDirection;
         }
 
-        public virtual bool Compatible(RealAntenna other) => RFBand == other.RFBand;
+        // Link Compatability
+        public virtual bool Compatible(RealAntenna other) => RFBand == other.RFBand && CanTransmitRF && other.CanReceiveRF;
+
+        public bool EitherDirectionCompatible(RealAntenna other) => Compatible(other) || other.Compatible(this);
+
         public virtual bool DirectionCheck(RealAntenna other) => DirectionCheck(other.Position);
         public virtual bool DirectionCheck(Vector3 pos) => Physics.PointingLoss(this, pos) < Physics.MaxPointingLoss;
 
@@ -125,6 +157,39 @@ namespace RealAntennas
                 SetDefaultTarget();
 
             EncoderOverride = (config.HasValue("EncoderOverride")) ? config.GetValue("EncoderOverride") : null;
+            // NOTE: key must match ModuleRealAntenna's persisted KSPField name
+            // (AntennaDutyMode), since this same method is used to rebuild a
+            // RealAntenna straight from a ProtoPartModuleSnapshot's saved values
+            // for unloaded vessels (RACommNetVessel.DiscoverAntennas), which is
+            // exactly the path Kerbalism's background sim relies on.
+            string sDuty = (config.HasValue("AntennaDutyMode")) ? config.GetValue("AntennaDutyMode") : AntennaDutyExtensions.DefaultModeName;
+            Duty = AntennaDutyExtensions.FromModeName(sDuty);
+            string sRole = (config.HasValue("LinkRoleMode")) ? config.GetValue("LinkRoleMode") : AntennaRFDirectionExtensions.DefaultModeName;
+            RFDirection = AntennaRFDirectionExtensions.FromModeName(sRole);
+        }
+
+        // Rebuilds this RealAntenna as the secondary transceiver of a dual-band
+        // ModuleRealAntenna, reading the "Secondary*"-prefixed config keys.
+        // Shares the physical dish with the primary - only band, direction and
+        // duty differ.
+        public virtual void LoadSecondaryFromConfigNode(ConfigNode config)
+        {
+            int tl = (config.HasValue("TechLevel")) ? int.Parse(config.GetValue("TechLevel")) : 0;
+            TechLevelInfo = TechLevelInfo.GetTechLevel(tl);
+            string sRFBand = (config.HasValue("SecondaryRFBand")) ? config.GetValue("SecondaryRFBand") : Antenna.BandInfo.All.Keys.DefaultIfEmpty("S").First();
+            RFBand = Antenna.BandInfo.Get(sRFBand);
+            referenceGain = (config.HasValue("referenceGain")) ? float.Parse(config.GetValue("referenceGain")) : 0;
+            referenceFrequency = (config.HasValue("referenceFrequency")) ? float.Parse(config.GetValue("referenceFrequency")) : 0;
+            antennaDiameter = (config.HasValue("antennaDiameter")) ? float.Parse(config.GetValue("antennaDiameter")) : 0;
+            Gain = (antennaDiameter > 0) ? Physics.GainFromDishDiamater(antennaDiameter, RFBand.Frequency, AntennaEfficiency) : Physics.GainFromReference(referenceGain, referenceFrequency * 1e6f, RFBand.Frequency);
+            TxPower = (config.HasValue("TxPower")) ? float.Parse(config.GetValue("TxPower")) : 30f;
+            SymbolRate = RFBand.MaxSymbolRate(TechLevelInfo.Level);
+            AMWTemp = (config.HasValue("AMWTemp")) ? float.Parse(config.GetValue("AMWTemp")) : 290f;
+            EncoderOverride = (config.HasValue("EncoderOverride")) ? config.GetValue("EncoderOverride") : null;
+            string sDuty = (config.HasValue("SecondaryAntennaDutyMode")) ? config.GetValue("SecondaryAntennaDutyMode") : AntennaDutyExtensions.DefaultModeName;
+            Duty = AntennaDutyExtensions.FromModeName(sDuty);
+            string sRole = (config.HasValue("SecondaryLinkRoleMode")) ? config.GetValue("SecondaryLinkRoleMode") : AntennaRFDirectionExtensions.DefaultModeName;
+            RFDirection = AntennaRFDirectionExtensions.FromModeName(sRole);
         }
 
         public virtual void ProcessUpgrades(float tsLevel, ConfigNode node)

--- a/src/RealAntennasProject/RealAntennaDigital.cs
+++ b/src/RealAntennasProject/RealAntennaDigital.cs
@@ -1,4 +1,4 @@
-﻿namespace RealAntennas
+namespace RealAntennas
 {
     public class RealAntennaDigital : RealAntenna
     {
@@ -31,6 +31,12 @@
         public override void LoadFromConfigNode(ConfigNode config)
         {
             base.LoadFromConfigNode(config);
+            modulator.LoadFromConfigNode(config);
+        }
+
+        public override void LoadSecondaryFromConfigNode(ConfigNode config)
+        {
+            base.LoadSecondaryFromConfigNode(config);
             modulator.LoadFromConfigNode(config);
         }
 

--- a/src/RealAntennasProject/RealAntennas.csproj
+++ b/src/RealAntennasProject/RealAntennas.csproj
@@ -45,6 +45,8 @@
     </ProjectReference>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <Compile Include="AntennaDuty.cs" />
+    <Compile Include="AntennaRFDirection.cs" />
     <Compile Include="HomeNodeTypes.cs" />
     <Compile Include="MapUI\Settings.cs" />
     <Compile Include="Network\ConnectionDebugger.cs" />

--- a/src/RealAntennasProject/Tools.cs
+++ b/src/RealAntennasProject/Tools.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using CommNet;
 using System.Linq;
 using Unity.Mathematics;
@@ -55,7 +55,7 @@ namespace RealAntennas
             {
                 foreach (RealAntenna ra in node.RAAntennaList)
                 {
-                    if (peer.Compatible(ra) && ra.Gain > highestGain)
+                    if (peer.EitherDirectionCompatible(ra) && ra.Gain > highestGain)
                     {
                         highestGain = ra.Gain;
                         result = ra;


### PR DESCRIPTION
Hi there, 
I hope it's okay to make a PR (Sorry for the bunch of commits, I'm still lowk new to github)
I love the mod and have wanted a few features added so i went ahead and created them:
Antenna Duty: real life probes can have different antennas for the Telemetry and Data transmission, So i wanted to add a toggle between Telemetry only, Science Only, or Dual duty, with default for both. Further, i wanted to be able to specify an Antenna as only an Uplink or a Downlink, I.e an antenna can be set to only send Science data back to KSC, whilst be controlled with a cheaper telemetry antenna. Default is Dual Duty and Uplink & Downlink. Supports Kerbalism for Science transmission.
Multiple Transcievers on Antennas: again for some more realism, to simulate having multiple feeds into a single dish, I.e, can have a K-Band and X-band feed onto a dish, Dish Targetting still works, and the Secondary transceiver mirrors the primary, both transceivers capable of having antenna duty selected and different bands,
Probe control requires Telemetry comms: Added a difficulty slider for minimum data rate for telemetry in Bps
Adjusted the Planner and Debug gui to reflect having receive only and transmit only capabilites on an antenna, as well as a check that your telemetry data rate provides probe control at a distance.
Relay hop filtering: A science transmission needs a network comprised of antennas capable of transmitting science, whilst telemetry needs a telemetry capable network, so a science to science relay won't allow probe control, and a telemetry to telemetry relay will provide 0bps of science transmission rate.
Comnet Ground Stations can have telemetry / science specified in .cfg for RSS/RP-1/RO...

Needs a bunch more testing....
Let me know what you think.